### PR TITLE
feat: AUDIOMUSE_API_TOKEN bearer auth for AudioMuse-AI

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -1035,6 +1035,26 @@ AUDIOMUSE_AI_API_KEY=your_gemini_api_key_here
 
 ---
 
+### AUDIOMUSE_API_TOKEN
+**Description**: Bearer token for authenticating to AudioMuse-AI itself  
+**Type**: String  
+**Default**: Empty  
+**Example**:
+```bash
+AUDIOMUSE_API_TOKEN=4e1ad730643f5e1043...
+```
+**Notes**:
+- Required when AudioMuse-AI runs with `AUTH_ENABLED=true` and an `API_TOKEN` configured
+- Sent as `Authorization: Bearer <token>` on every request to AudioMuse-AI
+  (`/api/config` health check and `/chat/api/chatPlaylist` playlist generation)
+- Leave empty when AudioMuse-AI has authentication disabled
+- This is *separate* from `AUDIOMUSE_AI_API_KEY` (which is the
+  Gemini/OpenAI/Mistral key passed in the request body so AudioMuse can call
+  the LLM on OctoGen’s behalf)
+- Also supports Docker secrets via `AUDIOMUSE_API_TOKEN_FILE`
+
+---
+
 ### AUDIOMUSE_SONGS_PER_MIX
 **Description**: Number of songs from AudioMuse-AI per hybrid playlist  
 **Type**: Integer  
@@ -1309,7 +1329,7 @@ docker logs octogen | grep "Timezone:"
 | **Templates** | 1 | PLAYLIST_TEMPLATES_FILE |
 | **Last.fm** | 3 | LASTFM_ENABLED, LASTFM_API_KEY, LASTFM_USERNAME |
 | **ListenBrainz** | 3 | LISTENBRAINZ_ENABLED, LISTENBRAINZ_USERNAME, LISTENBRAINZ_TOKEN |
-| **AudioMuse-AI** | 7 | AUDIOMUSE_ENABLED, AUDIOMUSE_URL, AUDIOMUSE_AI_PROVIDER, AUDIOMUSE_AI_MODEL, AUDIOMUSE_AI_API_KEY, AUDIOMUSE_SONGS_PER_MIX, LLM_SONGS_PER_MIX |
+| **AudioMuse-AI** | 8 | AUDIOMUSE_ENABLED, AUDIOMUSE_URL, AUDIOMUSE_AI_PROVIDER, AUDIOMUSE_AI_MODEL, AUDIOMUSE_AI_API_KEY, AUDIOMUSE_API_TOKEN, AUDIOMUSE_SONGS_PER_MIX, LLM_SONGS_PER_MIX |
 | **Spotify Import** | 4 | SPOTIFY_IMPORT_ENABLED, SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, SPOTIFY_PLAYLIST_URLS |
 | **Deezer Import** | 2 | DEEZER_IMPORT_ENABLED, DEEZER_PLAYLIST_URLS |
 | **Performance** | 5 | PERF_ALBUM_BATCH_SIZE, PERF_MAX_ALBUMS_SCAN, PERF_SCAN_TIMEOUT, PERF_DOWNLOAD_DELAY, PERF_POST_SCAN_DELAY |

--- a/octogen/api/audiomuse.py
+++ b/octogen/api/audiomuse.py
@@ -10,40 +10,54 @@ logger = logging.getLogger(__name__)
 
 class AudioMuseClient:
     """Client for interacting with AudioMuse-AI API"""
-    
-    def __init__(self, base_url: str, ai_provider: str, ai_model: str, api_key: Optional[str] = None):
+
+    def __init__(self, base_url: str, ai_provider: str, ai_model: str,
+                 api_key: Optional[str] = None,
+                 audiomuse_api_token: Optional[str] = None):
         """Initialize AudioMuse-AI client
-        
+
         Args:
             base_url: AudioMuse-AI server URL
             ai_provider: AI provider (gemini, openai, ollama, mistral)
             ai_model: AI model name
-            api_key: Optional API key for AI provider
+            api_key: Optional API key for the AI provider (sent in JSON body
+                so AudioMuse can call the LLM on our behalf)
+            audiomuse_api_token: Optional Bearer token for authenticating to
+                AudioMuse-AI itself (required when AudioMuse-AI runs with
+                AUTH_ENABLED=true and an API_TOKEN configured). Sent as
+                ``Authorization: Bearer <token>`` on every request.
         """
         self.base_url = base_url.rstrip('/')
         self.ai_provider = ai_provider.upper()  # Normalize to uppercase for consistent comparison
         self.ai_model = ai_model
         self.api_key = api_key
-        
+        self.audiomuse_api_token = audiomuse_api_token
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Return Authorization header dict if a token is configured."""
+        if self.audiomuse_api_token:
+            return {"Authorization": f"Bearer {self.audiomuse_api_token}"}
+        return {}
+
     def generate_playlist(self, user_request: str, num_songs: int = 25) -> List[Dict]:
         """Generate playlist using AudioMuse-AI chat API
-        
+
         Args:
             user_request: Natural language request for playlist
             num_songs: Number of songs to request
-            
+
         Returns:
             List of song dictionaries with keys: title, artist, item_id
         """
         endpoint = f"{self.base_url}/chat/api/chatPlaylist"
-        
+
         payload = {
             "userInput": user_request,
             "ai_provider": self.ai_provider,
             "ai_model": self.ai_model,
             "get_songs": num_songs
         }
-        
+
         # Add API key if provided (case-sensitive comparison with normalized uppercase provider)
         if self.api_key:
             if self.ai_provider == "GEMINI":
@@ -53,22 +67,22 @@ class AudioMuseClient:
             elif self.ai_provider == "MISTRAL":
                 payload["mistral_api_key"] = self.api_key
         payload = {k: v for k, v in payload.items() if v is not None and str(v).lower() != "null"}
-        
+
         try:
             logger.debug(f"AudioMuse API request: {endpoint}")
             logger.debug(f"Requesting {num_songs} songs with provider {self.ai_provider}")
-            response = requests.post(endpoint, json=payload, timeout=60)
+            response = requests.post(endpoint, json=payload, headers=self._auth_headers(), timeout=60)
             response.raise_for_status()
-            
+
             data = response.json()
             response_data = data.get('response', data)
             songs = response_data.get('query_results') or []
-            
+
             logger.info(f"AudioMuse-AI returned {len(songs)} songs for request: '{user_request}'")
             if len(songs) < num_songs:
                 logger.debug(f"AudioMuse returned fewer songs than requested ({len(songs)}/{num_songs})")
             return songs
-            
+
         except requests.exceptions.Timeout as e:
             logger.error(f"AudioMuse-AI API timeout after 60s: {e}")
             return []
@@ -81,16 +95,16 @@ class AudioMuseClient:
         except Exception as e:
             logger.error(f"Unexpected error in AudioMuse-AI request: {e}")
             return []
-    
+
     def check_health(self) -> bool:
         """Check if AudioMuse-AI server is accessible
-        
+
         Returns:
             True if server is healthy, False otherwise
         """
         try:
             logger.debug(f"Checking AudioMuse-AI health at {self.base_url}")
-            response = requests.get(f"{self.base_url}/api/config", timeout=5)
+            response = requests.get(f"{self.base_url}/api/config", headers=self._auth_headers(), timeout=5)
             is_healthy = response.status_code == 200
             if is_healthy:
                 logger.debug("AudioMuse-AI health check passed")

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -82,7 +82,7 @@ def load_config_from_env() -> Dict:
             "ai_provider": os.getenv("AUDIOMUSE_AI_PROVIDER", "gemini"),
             "ai_model": os.getenv("AUDIOMUSE_AI_MODEL", "gemini-2.5-flash"),
             "ai_api_key": load_secret("AUDIOMUSE_AI_API_KEY"),
-            "api_token": load_secret("AUDIOMUSE_API_TOKEN"),
+            "api_token": load_secret("AUDIOMUSE_API_TOKEN", ""),
         },
         "spotify": {
             "enabled": os.getenv("SPOTIFY_IMPORT_ENABLED", "false").lower() == "true",

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -82,6 +82,7 @@ def load_config_from_env() -> Dict:
             "ai_provider": os.getenv("AUDIOMUSE_AI_PROVIDER", "gemini"),
             "ai_model": os.getenv("AUDIOMUSE_AI_MODEL", "gemini-2.5-flash"),
             "ai_api_key": load_secret("AUDIOMUSE_AI_API_KEY"),
+            "api_token": load_secret("AUDIOMUSE_API_TOKEN"),
         },
         "spotify": {
             "enabled": os.getenv("SPOTIFY_IMPORT_ENABLED", "false").lower() == "true",

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -141,7 +141,8 @@ class OctoGenEngine:
                 base_url=audiomuse_url,
                 ai_provider=self.config["audiomuse"]["ai_provider"],
                 ai_model=self.config["audiomuse"]["ai_model"],
-                api_key=self.config["audiomuse"]["ai_api_key"] or None
+                api_key=self.config["audiomuse"]["ai_api_key"] or None,
+                audiomuse_api_token=self.config["audiomuse"]["api_token"] or None,
             )
             if audiomuse_client.check_health():
                 logger.info("✅ AudioMuse-AI connected at %s", audiomuse_url)
@@ -271,6 +272,7 @@ class OctoGenEngine:
                 "ai_provider": os.getenv("AUDIOMUSE_AI_PROVIDER", "gemini"),
                 "ai_model": os.getenv("AUDIOMUSE_AI_MODEL", "gemini-2.5-flash"),
                 "ai_api_key": os.getenv("AUDIOMUSE_AI_API_KEY", ""),
+                "api_token": load_secret("AUDIOMUSE_API_TOKEN", ""),
                 "songs_per_mix": self._get_env_int("AUDIOMUSE_SONGS_PER_MIX", 25),
                 "llm_songs_per_mix": self._get_env_int("LLM_SONGS_PER_MIX", 5)
             },

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import json
 from datetime import datetime, timezone
 
+from octogen.utils.secrets import load_secret
+
 logger = logging.getLogger(__name__)
 
 
@@ -243,8 +245,7 @@ def check_audiomuse() -> Dict[str, Any]:
                 "healthy": False
             }
         
-        from octogen.utils.secrets import load_secret
-        api_token = load_secret("AUDIOMUSE_API_TOKEN")
+        api_token = load_secret("AUDIOMUSE_API_TOKEN", "")
         headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
 
         # Try to check health using /api/config endpoint

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -243,9 +243,14 @@ def check_audiomuse() -> Dict[str, Any]:
                 "healthy": False
             }
         
+        from octogen.utils.secrets import load_secret
+        api_token = load_secret("AUDIOMUSE_API_TOKEN")
+        headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
+
         # Try to check health using /api/config endpoint
         response = requests.get(
             f"{url}/api/config",  # Changed from /health to /api/config
+            headers=headers,
             timeout=5
         )
         

--- a/tests/test_audiomuse_auth.py
+++ b/tests/test_audiomuse_auth.py
@@ -1,0 +1,73 @@
+"""Tests for AudioMuse-AI bearer-token auth.
+
+Locks in the AUDIOMUSE_API_TOKEN bearer-auth behavior so a future change to
+header construction or token wiring fails CI instead of silently dropping
+the Authorization header.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from octogen.api.audiomuse import AudioMuseClient
+
+
+def _make_client(token=None):
+    return AudioMuseClient(
+        base_url="http://audiomuse.test",
+        ai_provider="gemini",
+        ai_model="gemini-2.5-flash",
+        audiomuse_api_token=token,
+    )
+
+
+class TestAuthHeaders:
+    def test_no_token_returns_empty_headers(self):
+        assert _make_client(token=None)._auth_headers() == {}
+
+    def test_empty_token_returns_empty_headers(self):
+        assert _make_client(token="")._auth_headers() == {}
+
+    def test_token_returns_bearer_header(self):
+        headers = _make_client(token="abc123")._auth_headers()
+        assert headers == {"Authorization": "Bearer abc123"}
+
+
+class TestGeneratePlaylistHeaderInjection:
+    @patch("octogen.api.audiomuse.requests.post")
+    def test_includes_bearer_when_token_set(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"response": {"query_results": []}},
+        )
+        _make_client(token="t0k").generate_playlist("any", num_songs=5)
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"] == {"Authorization": "Bearer t0k"}
+
+    @patch("octogen.api.audiomuse.requests.post")
+    def test_no_auth_header_when_token_missing(self, mock_post):
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"response": {"query_results": []}},
+        )
+        _make_client(token=None).generate_playlist("any", num_songs=5)
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"] == {}
+
+
+class TestCheckHealthHeaderInjection:
+    @patch("octogen.api.audiomuse.requests.get")
+    def test_includes_bearer_when_token_set(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200)
+        _make_client(token="t0k").check_health()
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"] == {"Authorization": "Bearer t0k"}
+
+    @patch("octogen.api.audiomuse.requests.get")
+    def test_no_auth_header_when_token_missing(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=200)
+        _make_client(token=None).check_health()
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"] == {}


### PR DESCRIPTION
## Summary

Adds optional Bearer-token authentication for talking to AudioMuse-AI, so OctoGen can connect to AudioMuse instances running with `AUTH_ENABLED=true` and an `API_TOKEN` configured.

- New `AUDIOMUSE_API_TOKEN` env var (with `_FILE` Docker-secret variant via `load_secret`)
- `AudioMuseClient` sends `Authorization: Bearer <token>` on `/api/config` (health) and `/chat/api/chatPlaylist` (playlist generation)
- Dashboard `check_audiomuse()` health probe in `web/health.py` mirrors the same header
- Empty/unset token → no header → existing unauthenticated deployments unaffected
- Distinct from `AUDIOMUSE_AI_API_KEY` (the LLM-provider key sent in the request body)

Closes #43.

## Test plan

- [ ] With `AUDIOMUSE_API_TOKEN` unset: existing deployments still pass health check and generate playlists
- [ ] With `AUDIOMUSE_API_TOKEN` set against an AudioMuse-AI running with `AUTH_ENABLED=true`: `/api/config` returns 200, `/chat/api/chatPlaylist` returns songs
- [ ] With wrong/missing token against an authenticated AudioMuse-AI: clear 401 in OctoGen logs (loud failure)
- [ ] Docker secrets path: `AUDIOMUSE_API_TOKEN_FILE=/run/secrets/audiomuse_token` resolves correctly via `load_secret`
