### PR TITLE
fix: dashboard Next Run drift when TZ != UTC

### DIFF
--- a/octogen/main.py
+++ b/octogen/main.py
@@ -517,19 +517,18 @@ class OctoGenEngine:
             for service_name, service_info in self.service_tracker.services.items():
                 services_data[service_name] = service_info
             
-            # Calculate next scheduled run if SCHEDULE_CRON is set
+            # Use calculate_next_run() so the cron is evaluated in the configured
+            # TZ — matches the scheduler in run_with_schedule, otherwise dashboard
+            # "Next Run" drifts when TZ != UTC.
             next_scheduled_run = None
             schedule_cron = os.getenv("SCHEDULE_CRON", "").strip()
-            
+
             if schedule_cron and schedule_cron.lower() not in ("manual", "false", "no", "off", "disabled"):
                 try:
-                    # Import croniter if available
                     if CRONITER_AVAILABLE:
-                        from croniter import croniter
-                        cron = croniter(schedule_cron, now)
-                        next_run_time = cron.get_next(datetime)
+                        next_run_time = calculate_next_run(schedule_cron)
                         next_scheduled_run = next_run_time.isoformat()
-                        logger.debug(f"Next scheduled run: {next_run_time.strftime('%Y-%m-%d %H:%M:%S')}")
+                        logger.debug(f"Next scheduled run: {next_run_time.strftime('%Y-%m-%d %H:%M:%S %Z')}")
                 except Exception as e:
                     logger.warning(f"Could not calculate next scheduled run: {e}")
             


### PR DESCRIPTION
## Summary

The dashboard `Next Run` time was computed from a UTC-naive `now` fed straight into `croniter`, so the cron expression was evaluated in UTC even when the scheduler runs it in the configured `TZ`. The dashboard drifted from the scheduler by the UTC offset (e.g. 1h off in PDT for a fixed-hour cron like `0 4,10,16,22 * * *`).

- Replace the inline `croniter` call in `record_successful_run()` with the existing `calculate_next_run()` helper from `octogen/scheduler/cron.py` — already used by the actual scheduler at `run_with_schedule()`, already builds `now` in the configured TZ
- No new imports (`calculate_next_run` is already imported at the top of `main.py`)
- Debug log format gains `%Z` so the timezone is visible in the next-run line

## Test plan

- [ ] With `TZ=America/Los_Angeles` and `SCHEDULE_CRON="0 4,10,16,22 * * *"`: dashboard `Next Run` matches scheduler log `Waiting Xs until next run at ...`
- [ ] With `TZ=UTC`: behavior unchanged from before
- [ ] With `SCHEDULE_CRON=manual` / unset: `next_scheduled_run` is `null` in the run-tracker JSON
