### PR TITLE
fix: import GEMINI_SDK_AVAILABLE in main.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ENV/
 # IDE
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -36,7 +36,7 @@ from octogen.api.listenbrainz import ListenBrainzAPI
 from octogen.api.audiomuse import AudioMuseClient
 from octogen.api.spotify import SpotifyImporter
 from octogen.api.deezer import DeezerImporter
-from octogen.ai.engine import AIRecommendationEngine
+from octogen.ai.engine import AIRecommendationEngine, GEMINI_SDK_AVAILABLE
 from octogen.models.tracker import ServiceTracker, RunTracker
 from octogen.web.health import write_health_status
 from octogen.scheduler.cron import calculate_next_run, wait_until, calculate_cron_interval


### PR DESCRIPTION
Imports `GEMINI_SDK_AVAILABLE` from `octogen.ai.engine` so the guard at `octogen/main.py:963` does not raise `NameError` when the Gemini backend is selected.

The flag is defined at `octogen/ai/engine.py:29/31` (try/except on `from google import genai`). `main.py` references it but does not import it.

## Test plan
- [ ] Start with `AI_BACKEND=gemini` and `google-genai` installed → no NameError
- [ ] Start with `AI_BACKEND=gemini` and `google-genai` missing → fails fast with the existing error message instead of NameError