### PR TITLE
feat: fall back to most-played albums when starred set is too small

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ ENV/
 # IDE
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -204,6 +204,38 @@ AI_REQUEST_TIMEOUT=600
 
 ---
 
+### SEED_FALLBACK_MIN
+**Description**: When the user has fewer than this many starred songs, OctoGen augments the AI seed with songs from the user's most-played albums. This avoids `min_total_token_count` errors from the Gemini context cache (1024-token floor) for users who don't favorite many songs.
+**Default**: `50`
+**Example**:
+```bash
+SEED_FALLBACK_MIN=50
+```
+**Notes**:
+- Set to `0` to disable the fallback entirely (only starred songs will seed the LLM)
+
+---
+
+### SEED_FALLBACK_TARGET
+**Description**: Target total seed size after augmenting with most-played albums. Augmentation stops once the seed reaches this size.
+**Default**: `500`
+**Example**:
+```bash
+SEED_FALLBACK_TARGET=500
+```
+
+---
+
+### SEED_FALLBACK_ALBUM_COUNT
+**Description**: Number of most-played albums to pull from Subsonic `getAlbumList2?type=frequent` when augmenting the seed.
+**Default**: `100`
+**Example**:
+```bash
+SEED_FALLBACK_ALBUM_COUNT=100
+```
+
+---
+
 ## 🕐 Scheduling Configuration (Optional)
 
 ### SCHEDULE_CRON

--- a/octogen/api/navidrome.py
+++ b/octogen/api/navidrome.py
@@ -35,6 +35,13 @@ class NavidromeAPI:
     LIBRARY_SEARCH_LIMIT = 30  # Max songs per search strategy in library search
     SIMILAR_SEARCH_LIMIT = 50  # Max songs for similar song detection
 
+    # Seed-fallback heuristic: estimate how many albums to fetch to cover N
+    # additional songs. Most albums hold ~10 songs; fetch a small buffer so we
+    # don't have to round-trip again if a few albums come up short.
+    AVG_SONGS_PER_ALBUM = 10
+    ALBUM_FETCH_BUFFER = 5
+    MIN_ALBUMS_TO_FETCH = 5
+
     def __init__(self, url: str, username: str, password: str,
                  ratings_cache: RatingsCache, config: dict):
         """Initialize Navidrome API client.
@@ -139,6 +146,11 @@ class NavidromeAPI:
         (Subsonic ``getAlbumList2?type=frequent``) until
         ``SEED_FALLBACK_TARGET`` is reached.
 
+        NOTE: This method is sync and uses ``asyncio.run()`` internally for the
+        parallel album fetch. It cannot be called from inside a running event
+        loop. If a caller is async, it should call
+        ``_fetch_albums_songs_parallel()`` directly via ``await``.
+
         Returns:
             List of seed song dictionaries.
         """
@@ -157,10 +169,14 @@ class NavidromeAPI:
                 {"type": "frequent", "size": self.seed_fallback_album_count},
             )
             albums = (albums_resp or {}).get("albumList2", {}).get("album", [])
-            # Most albums hold ~10+ songs; cap fetch count so we don't make 100 album
-            # requests when ~25 satisfies seed_fallback_target.
             needed = max(0, self.seed_fallback_target - len(songs))
-            estimated_albums = min(len(albums), max(5, (needed // 10) + 5))
+            estimated_albums = min(
+                len(albums),
+                max(
+                    self.MIN_ALBUMS_TO_FETCH,
+                    (needed // self.AVG_SONGS_PER_ALBUM) + self.ALBUM_FETCH_BUFFER,
+                ),
+            )
             albums = albums[:estimated_albums]
             album_ids = [a["id"] for a in albums if a.get("id")]
             album_song_lists = asyncio.run(self._fetch_albums_songs_parallel(album_ids))
@@ -188,16 +204,29 @@ class NavidromeAPI:
                 "Added %d songs from %d most-played albums (total seed: %d)",
                 added, len(albums), len(songs),
             )
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError, KeyError, TypeError, ValueError) as e:
             logger.warning("Most-played seed augmentation failed: %s", str(e)[:200])
 
         return songs
 
     async def _fetch_albums_songs_parallel(self, album_ids: List[str]) -> List[List[Dict]]:
-        """Fetch songs for multiple albums in parallel."""
+        """Fetch songs for multiple albums in parallel.
+
+        Uses ``return_exceptions=True`` so a single album fetch failure does
+        not cancel the whole batch. Failed fetches show up as empty lists in
+        the result.
+        """
         async with aiohttp.ClientSession() as session:
             tasks = [self._fetch_album_songs_async(session, aid) for aid in album_ids]
-            return await asyncio.gather(*tasks)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+        clean: List[List[Dict]] = []
+        for aid, result in zip(album_ids, results):
+            if isinstance(result, BaseException):
+                logger.debug("Album %s fetch failed: %s", aid, result)
+                clean.append([])
+            else:
+                clean.append(result)
+        return clean
 
     def get_song_rating(self, song_id: str) -> int:
         """Get rating for a song (0-5 stars).

--- a/octogen/api/navidrome.py
+++ b/octogen/api/navidrome.py
@@ -57,6 +57,11 @@ class NavidromeAPI:
         self.max_albums = config.get("performance", {}).get("max_albums_scan", 10000)
         self.scan_timeout = config.get("performance", {}).get("scan_timeout", 60)
 
+        ai_cfg = config.get("ai", {})
+        self.seed_fallback_min = ai_cfg.get("seed_fallback_min", 50)
+        self.seed_fallback_target = ai_cfg.get("seed_fallback_target", 500)
+        self.seed_fallback_album_count = ai_cfg.get("seed_fallback_album_count", 100)
+
     def _request(self, endpoint: str, extra_params: dict = None) -> Optional[dict]:
         """Make Subsonic API request.
         
@@ -101,7 +106,7 @@ class NavidromeAPI:
 
     def get_starred_songs(self) -> List[Dict]:
         """Get all starred songs.
-        
+
         Returns:
             List of starred song dictionaries
         """
@@ -120,8 +125,79 @@ class NavidromeAPI:
                 "album": song.get("album", ""),
                 "genre": song.get("genre", "Unknown"),
             })
+        return songs
+
+    def get_seed_songs(self) -> List[Dict]:
+        """Get songs to seed the AI recommendation engine.
+
+        Returns starred songs, falling back to most-played albums when the
+        starred set is too small. The Gemini context cache requires at least
+        1024 tokens of seed metadata; users with few starred songs hit
+        ``min_total_token_count`` errors and lose the LLM half of every
+        hybrid playlist. When starred count is below ``SEED_FALLBACK_MIN``,
+        augment with songs from the user's most-played albums
+        (Subsonic ``getAlbumList2?type=frequent``) until
+        ``SEED_FALLBACK_TARGET`` is reached.
+
+        Returns:
+            List of seed song dictionaries.
+        """
+        songs = self.get_starred_songs()
+
+        if len(songs) >= self.seed_fallback_min:
+            return songs
+
+        logger.info(
+            "Only %d starred songs (< %d) — augmenting AI seed with most-played albums",
+            len(songs), self.seed_fallback_min,
+        )
+        try:
+            albums_resp = self._request(
+                "getAlbumList2",
+                {"type": "frequent", "size": self.seed_fallback_album_count},
+            )
+            albums = (albums_resp or {}).get("albumList2", {}).get("album", [])
+            # Most albums hold ~10+ songs; cap fetch count so we don't make 100 album
+            # requests when ~25 satisfies seed_fallback_target.
+            needed = max(0, self.seed_fallback_target - len(songs))
+            estimated_albums = min(len(albums), max(5, (needed // 10) + 5))
+            albums = albums[:estimated_albums]
+            album_ids = [a["id"] for a in albums if a.get("id")]
+            album_song_lists = asyncio.run(self._fetch_albums_songs_parallel(album_ids))
+
+            seen_ids = {s["id"] for s in songs}
+            added = 0
+            for album, album_songs in zip(albums, album_song_lists):
+                if len(songs) >= self.seed_fallback_target:
+                    break
+                for s in album_songs:
+                    if s["id"] in seen_ids:
+                        continue
+                    seen_ids.add(s["id"])
+                    songs.append({
+                        "id": s["id"],
+                        "title": s["title"],
+                        "artist": s.get("artist", album.get("artist", "")),
+                        "album": s.get("album", album.get("name", "")),
+                        "genre": s.get("genre", "Unknown"),
+                    })
+                    added += 1
+                    if len(songs) >= self.seed_fallback_target:
+                        break
+            logger.info(
+                "Added %d songs from %d most-played albums (total seed: %d)",
+                added, len(albums), len(songs),
+            )
+        except Exception as e:
+            logger.warning("Most-played seed augmentation failed: %s", str(e)[:200])
 
         return songs
+
+    async def _fetch_albums_songs_parallel(self, album_ids: List[str]) -> List[List[Dict]]:
+        """Fetch songs for multiple albums in parallel."""
+        async with aiohttp.ClientSession() as session:
+            tasks = [self._fetch_album_songs_async(session, aid) for aid in album_ids]
+            return await asyncio.gather(*tasks)
 
     def get_song_rating(self, song_id: str) -> int:
         """Get rating for a song (0-5 stars).

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -247,6 +247,9 @@ class OctoGenEngine:
                 "max_context_songs": self._get_env_int("AI_MAX_CONTEXT_SONGS", 500),
                 "max_output_tokens": self._get_env_int("AI_MAX_OUTPUT_TOKENS", 65535),
                 "request_timeout": max(30, self._get_env_int("AI_REQUEST_TIMEOUT", 300)),
+                "seed_fallback_min": self._get_env_int("SEED_FALLBACK_MIN", 50),
+                "seed_fallback_target": self._get_env_int("SEED_FALLBACK_TARGET", 500),
+                "seed_fallback_album_count": self._get_env_int("SEED_FALLBACK_ALBUM_COUNT", 100),
             },
             "performance": {
                 "album_batch_size": self._get_env_int("PERF_ALBUM_BATCH_SIZE", 500),
@@ -1029,8 +1032,8 @@ CRITICAL RULES:
             write_health_status(BASE_DIR, "running", "Analyzing music library")
             # Analyze library
             logger.info("Analyzing music library...")
-            logger.debug("Fetching starred songs from Navidrome")
-            favorited_songs = self.nd.get_starred_songs()
+            logger.debug("Fetching seed songs from Navidrome")
+            favorited_songs = self.nd.get_seed_songs()
     
             if not favorited_songs:
                 logger.warning("No starred songs found - library analysis limited")

--- a/tests/test_seed_fallback.py
+++ b/tests/test_seed_fallback.py
@@ -1,0 +1,153 @@
+"""Tests for NavidromeAPI.get_seed_songs() seed-fallback behavior.
+
+Locks in the bug-driven feature: when the starred-song set is too small for
+Gemini's 1024-token context-cache floor, augment with most-played-album songs
+until SEED_FALLBACK_TARGET is reached.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from octogen.api.navidrome import NavidromeAPI
+
+
+def _make_api(min_threshold=50, target=500, album_count=100):
+    """Construct a NavidromeAPI with a mocked ratings cache and minimal config."""
+    api = NavidromeAPI.__new__(NavidromeAPI)
+    api.url = "http://navidrome.test"
+    api.username = "u"
+    api.password = "p"
+    api.session = MagicMock()
+    api.ratings_cache = MagicMock()
+    api.album_batch_size = 500
+    api.max_albums = 10000
+    api.scan_timeout = 60
+    api.seed_fallback_min = min_threshold
+    api.seed_fallback_target = target
+    api.seed_fallback_album_count = album_count
+    return api
+
+
+def _starred(n):
+    return [
+        {"id": f"s{i}", "title": f"t{i}", "artist": "a", "album": "x", "genre": "g"}
+        for i in range(n)
+    ]
+
+
+def _album_songs(album_id, count, start=1000):
+    return [
+        {"id": f"{album_id}-song{i}", "title": f"st{i}", "artist": "aa", "album": "alb", "genre": "g"}
+        for i in range(start, start + count)
+    ]
+
+
+class TestSeedFallbackThreshold:
+    def test_returns_starred_unchanged_when_above_threshold(self):
+        api = _make_api(min_threshold=50)
+        with patch.object(api, "get_starred_songs", return_value=_starred(60)):
+            songs = api.get_seed_songs()
+        assert len(songs) == 60
+        assert all(s["id"].startswith("s") for s in songs)
+
+    def test_augments_when_below_threshold(self):
+        api = _make_api(min_threshold=50, target=100)
+        starred = _starred(10)
+        albums_payload = {
+            "albumList2": {
+                "album": [
+                    {"id": "alb1", "name": "A1", "artist": "AA"},
+                    {"id": "alb2", "name": "A2", "artist": "BB"},
+                ]
+            }
+        }
+        with patch.object(api, "get_starred_songs", return_value=starred), \
+             patch.object(api, "_request", return_value=albums_payload), \
+             patch.object(api, "_fetch_albums_songs_parallel", new=MagicMock()) as fetcher:
+            # MagicMock can't be awaited; replace with an AsyncMock-like wrapper.
+            async def _fake(album_ids):
+                return [_album_songs(aid, 30, start=1000) for aid in album_ids]
+            fetcher.side_effect = lambda ids: _fake(ids)
+            # asyncio.run will run our coroutine
+            songs = api.get_seed_songs()
+        assert len(songs) > 10  # augmented
+        # Original starred IDs are preserved at the front
+        assert [s["id"] for s in songs[:10]] == [f"s{i}" for i in range(10)]
+
+
+class TestSeedFallbackDedup:
+    def test_deduplicates_against_starred(self):
+        api = _make_api(min_threshold=50, target=20)
+        starred = _starred(5)
+        # Album song shares an id with starred song s0
+        albums_payload = {"albumList2": {"album": [{"id": "alb1", "name": "A1", "artist": "AA"}]}}
+
+        async def _fake(album_ids):
+            # Return one duplicate (s0) and several unique
+            dup = {"id": "s0", "title": "dup", "artist": "x", "album": "x", "genre": "g"}
+            uniq = _album_songs("alb1", 5, start=2000)
+            return [[dup] + uniq]
+
+        with patch.object(api, "get_starred_songs", return_value=starred), \
+             patch.object(api, "_request", return_value=albums_payload), \
+             patch.object(api, "_fetch_albums_songs_parallel", side_effect=_fake):
+            songs = api.get_seed_songs()
+        ids = [s["id"] for s in songs]
+        assert ids.count("s0") == 1
+        # Should have at most starred (5) + 5 unique album songs
+        assert len(songs) == 10
+
+
+class TestSeedFallbackTargetCap:
+    def test_stops_at_target(self):
+        api = _make_api(min_threshold=50, target=12)
+        starred = _starred(2)
+        albums_payload = {
+            "albumList2": {
+                "album": [
+                    {"id": "alb1", "name": "A1", "artist": "AA"},
+                    {"id": "alb2", "name": "A2", "artist": "BB"},
+                ]
+            }
+        }
+
+        async def _fake(album_ids):
+            return [_album_songs(aid, 50, start=3000) for aid in album_ids]
+
+        with patch.object(api, "get_starred_songs", return_value=starred), \
+             patch.object(api, "_request", return_value=albums_payload), \
+             patch.object(api, "_fetch_albums_songs_parallel", side_effect=_fake):
+            songs = api.get_seed_songs()
+        assert len(songs) == 12
+
+
+class TestSeedFallbackFailure:
+    def test_returns_starred_when_augmentation_raises(self):
+        api = _make_api(min_threshold=50, target=100)
+        starred = _starred(10)
+        with patch.object(api, "get_starred_songs", return_value=starred), \
+             patch.object(api, "_request", side_effect=KeyError("bad shape")):
+            songs = api.get_seed_songs()
+        # Augmentation failed but starred songs are still returned
+        assert songs == starred
+
+
+class TestParallelFetchResilience:
+    """_fetch_albums_songs_parallel uses return_exceptions=True so a single
+    album failure does not collapse the whole batch."""
+
+    def test_one_failure_does_not_cancel_others(self):
+        import asyncio as _asyncio
+
+        api = _make_api()
+
+        async def fake_one(session, aid):
+            if aid == "bad":
+                raise RuntimeError("boom")
+            return [{"id": f"{aid}-1", "title": "t", "artist": "a", "album": "a", "genre": "g"}]
+
+        with patch.object(api, "_fetch_album_songs_async", side_effect=fake_one):
+            results = _asyncio.run(api._fetch_albums_songs_parallel(["good", "bad", "good2"]))
+
+        assert results[0] == [{"id": "good-1", "title": "t", "artist": "a", "album": "a", "genre": "g"}]
+        assert results[1] == []  # failure replaced with empty list
+        assert results[2] == [{"id": "good2-1", "title": "t", "artist": "a", "album": "a", "genre": "g"}]


### PR DESCRIPTION
Users with few starred songs hit Gemini context cache `min_total_token_count=1024` errors and lose the LLM half of every hybrid playlist (Daily Mix N reports AudioMuse:100, LLM:0).

## Changes
- New `get_seed_songs()` method on `NavidromeAPI` — wraps `get_starred_songs()`, augments with songs from most-played albums via Subsonic `getAlbumList2?type=frequent` + parallel `getAlbum` fetches
- `get_starred_songs()` is unchanged — `get_top_artists`/`get_top_genres` keep starred-only semantics
- `main.py` AI seed path now calls `get_seed_songs()`
- Album-fetch count is capped to ~estimated need to avoid 100 unnecessary album lookups

## New env vars (all optional, flow through `config["ai"]`)
- `SEED_FALLBACK_MIN` (default 50) — trigger threshold; set 0 to disable
- `SEED_FALLBACK_TARGET` (default 500) — stop once seed reaches this size
- `SEED_FALLBACK_ALBUM_COUNT` (default 100) — max albums pulled from frequent

## Test plan
- [ ] Star <50 songs in Navidrome → run; logs show "augmenting AI seed" and total seed reaches ~500
- [ ] Star >=50 songs → no fallback log, behavior unchanged
- [ ] `SEED_FALLBACK_MIN=0` → no fallback even with 0 starred
- [ ] AudioMuse Daily Mix LLM count > 0 after fallback runs