### PR TITLE
Add OCTOFIESTA_ENABLED toggle to make Octo-Fiesta optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ NAVIDROME_USER=admin
 NAVIDROME_PASSWORD=your_navidrome_password
 
 # ============================================================================
-# REQUIRED - Octo-Fiesta Server (for downloads)
+# Octo-Fiesta Server (downloads missing tracks)
 # ============================================================================
+# Set OCTOFIESTA_ENABLED=false for local-only mode (URL no longer required).
+OCTOFIESTA_ENABLED=true
 OCTOFIESTA_URL=http://192.168.1.100:5274
 
 # ============================================================================

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -47,6 +47,20 @@ NAVIDROME_PASSWORD=your_secure_password
 
 ---
 
+### OCTOFIESTA_ENABLED
+**Description**: Enable Octo-Fiesta downloads for missing tracks
+**Default**: `true`
+**Options**: `true`, `false`
+**Example**:
+```bash
+OCTOFIESTA_ENABLED=false
+```
+**Notes**:
+- When `false`, OctoGen runs in local-only mode: missing tracks are excluded from playlists and `OCTOFIESTA_URL` is not required.
+- One summary line per run reports the skip count.
+
+---
+
 ### OCTOFIESTA_URL
 **Description**: URL of your Octo-Fiesta server  
 **Format**: `http://hostname:port`  
@@ -58,6 +72,7 @@ OCTOFIESTA_URL=http://octo-fiesta:8080
 **Notes**:
 - Required for automatic downloading of missing tracks
 - Uses same Navidrome credentials
+- Required only when `OCTOFIESTA_ENABLED=true` (the default).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See [AudioMuse-AI Setup](#-audiomuse-ai-setup-optional) below.
 ### 🎯 Smart Features
 - **Star rating filtering**: Excludes 1-2 star rated songs
 - **Duplicate detection**: No repeated tracks across playlists
-- **Automatic downloads**: Missing songs fetched via Octo-Fiesta
+- **Optional Octo-Fiesta integration** — auto-download missing tracks, or run local-only with `OCTOFIESTA_ENABLED=false`
 - **Daily cache**: Efficient library scanning
 - **Async operations**: Fast, parallel processing
 - **LastFM, ListenBrainz & AudioMuse-AI**: Optional integrations

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -27,13 +27,15 @@ def load_config_from_env() -> Dict:
     """
     logger.info("Loading configuration from environment variables...")
 
-    # Check required variables
+    octofiesta_enabled = os.getenv("OCTOFIESTA_ENABLED", "true").lower() == "true"
+
     required_vars = [
         "NAVIDROME_URL",
         "NAVIDROME_USER",
         "NAVIDROME_PASSWORD",
-        "OCTOFIESTA_URL"
     ]
+    if octofiesta_enabled:
+        required_vars.append("OCTOFIESTA_URL")
 
     missing = [var for var in required_vars if not load_secret(var)]
     if missing:
@@ -43,7 +45,9 @@ def load_config_from_env() -> Dict:
         logger.error("  NAVIDROME_URL       - Navidrome server URL")
         logger.error("  NAVIDROME_USER      - Navidrome username")
         logger.error("  NAVIDROME_PASSWORD  - Navidrome password")
-        logger.error("  OCTOFIESTA_URL      - Octo-Fiesta server URL")
+        if octofiesta_enabled:
+            logger.error("  OCTOFIESTA_URL      - Octo-Fiesta server URL")
+            logger.error("                        (set OCTOFIESTA_ENABLED=false to disable downloads)")
         logger.error("")
         logger.error("See ENV_VARS.md for complete reference")
         sys.exit(1)
@@ -55,7 +59,8 @@ def load_config_from_env() -> Dict:
             "password": load_secret("NAVIDROME_PASSWORD"),
         },
         "octofiesta": {
-            "url": load_secret("OCTOFIESTA_URL"),
+            "enabled": octofiesta_enabled,
+            "url": load_secret("OCTOFIESTA_URL") if octofiesta_enabled else None,
         },
         "ai": {
             "api_key": load_secret("AI_API_KEY"),

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -830,6 +830,17 @@ class OctoGenEngine:
         # Get configuration
         audiomuse_songs_count = self.config["audiomuse"]["songs_per_mix"]
         llm_songs_count = self.config["audiomuse"]["llm_songs_per_mix"]
+
+        # When Octo-Fiesta is disabled, LLM picks have no download path and
+        # silently drop out of the playlist. Clamp the LLM half to 0 so the
+        # mix is pure AudioMuse instead of half-empty.
+        if self.octo is None and llm_songs_count > 0:
+            logger.info(
+                "Octo-Fiesta disabled: skipping LLM half of %s "
+                "(LLM_SONGS_PER_MIX=%d ignored, AudioMuse-only)",
+                label, llm_songs_count,
+            )
+            llm_songs_count = 0
         
         # Get songs from AudioMuse-AI if enabled
         audiomuse_actual_count = 0
@@ -884,20 +895,29 @@ class OctoGenEngine:
                 num_llm_songs = llm_songs_count + shortfall + buffer
                 logger.info(f"🔄 AudioMuse returned {audiomuse_actual_count}/{audiomuse_songs_count} songs, "
                             f"requesting {num_llm_songs} from LLM (includes {buffer} song buffer)")
-        
-        logger.debug(f"Requesting {num_llm_songs} songs from LLM for {label}")
-        # We'll use the AI engine to generate just the LLM portion
-        llm_songs = self._generate_llm_songs_for_daily_mix(
-            mix_number=mix_number,
-            genre_focus=genre_focus,
-            characteristics=characteristics,
-            num_songs=num_llm_songs,
-            top_artists=top_artists,
-            top_genres=top_genres,
-            favorited_songs=favorited_songs,
-            low_rated_songs=low_rated_songs
-        )
-        
+
+        # Skip the LLM call entirely when Octo-Fiesta is disabled. Without a
+        # download path, LLM picks would just be dropped during track lookup
+        # (and the shortfall logic above would still inflate num_llm_songs).
+        if self.octo is None:
+            num_llm_songs = 0
+
+        if num_llm_songs > 0:
+            logger.debug(f"Requesting {num_llm_songs} songs from LLM for {label}")
+            # We'll use the AI engine to generate just the LLM portion
+            llm_songs = self._generate_llm_songs_for_daily_mix(
+                mix_number=mix_number,
+                genre_focus=genre_focus,
+                characteristics=characteristics,
+                num_songs=num_llm_songs,
+                top_artists=top_artists,
+                top_genres=top_genres,
+                favorited_songs=favorited_songs,
+                low_rated_songs=low_rated_songs
+            )
+        else:
+            llm_songs = []
+
         songs.extend(llm_songs)
         random.shuffle(songs)
         
@@ -1213,13 +1233,22 @@ CRITICAL RULES:
                     logger.info("AudioMuse-AI service succeeded: %d playlists", audiomuse_playlists)
                     
                     # Create Discovery from AI response (LLM-only for new discoveries)
+                    # Discovery is 100% LLM picks, so without a download path
+                    # (Octo-Fiesta) the resulting playlist is essentially empty.
+                    # Skip it entirely when OCTOFIESTA_ENABLED=false.
                     if "Discovery" in all_playlists:
-                        discovery_songs = all_playlists["Discovery"]
-                        if isinstance(discovery_songs, list) and discovery_songs:
-                            logger.info("=" * 70)
-                            logger.info("DISCOVERY (LLM-only for new discoveries)")
-                            logger.info("=" * 70)
-                            self.create_playlist("Discovery", discovery_songs, max_songs=50)
+                        if self.octo is None:
+                            logger.info(
+                                "Discovery skipped: requires OCTOFIESTA_ENABLED=true "
+                                "(LLM-only playlist needs Octo-Fiesta to fetch picks)"
+                            )
+                        else:
+                            discovery_songs = all_playlists["Discovery"]
+                            if isinstance(discovery_songs, list) and discovery_songs:
+                                logger.info("=" * 70)
+                                logger.info("DISCOVERY (LLM-only for new discoveries)")
+                                logger.info("=" * 70)
+                                self.create_playlist("Discovery", discovery_songs, max_songs=50)
                 else:
                     # Original behavior: use all AI-generated playlists
                     for playlist_name, songs in all_playlists.items():
@@ -1545,8 +1574,14 @@ CRITICAL RULES:
                         except Exception as e:
                             logger.warning(f"AudioMuse generation failed: {e}")
                     
-                    # Get 5 songs from LLM
-                    if self.ai and favorited_songs:
+                    # Get 5 songs from LLM (skip when Octo-Fiesta is disabled —
+                    # LLM picks have no download path and would just be dropped)
+                    if self.octo is None:
+                        logger.info(
+                            "Skipping LLM half of %s: requires OCTOFIESTA_ENABLED=true",
+                            playlist_name,
+                        )
+                    elif self.ai and favorited_songs:
                         logger.info("🤖 Generating 5 songs via LLM...")
                         try:
                             # Build a special prompt for time-period playlist

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -89,12 +89,16 @@ class OctoGenEngine:
             logger.error("Cannot connect to Navidrome")
             sys.exit(1)
 
-        self.octo = OctoFiestaTrigger(
-            self.config["octofiesta"]["url"],
-            self.config["navidrome"]["username"],
-            self.config["navidrome"]["password"],
-            dry_run=dry_run
-        )
+        if self.config["octofiesta"]["enabled"]:
+            self.octo = OctoFiestaTrigger(
+                self.config["octofiesta"]["url"],
+                self.config["navidrome"]["username"],
+                self.config["navidrome"]["password"],
+                dry_run=dry_run
+            )
+        else:
+            self.octo = None
+            logger.info("✓ Octo-Fiesta: disabled (OCTOFIESTA_ENABLED=false) — local-only mode")
 
         # Initialize AI engine (optional if other services are configured)
         self.ai = None
@@ -193,6 +197,7 @@ class OctoGenEngine:
             "songs_skipped_duplicate": 0,
             "duplicates_prevented": 0,
             "ai_calls": 0,
+            "fiesta_skipped": 0,
         }
 
         # Track processed songs to avoid duplicates
@@ -210,12 +215,14 @@ class OctoGenEngine:
         logger.info("Loading configuration from environment variables...")
 
         # Check required variables (except AI_API_KEY which is now optional)
+        octofiesta_enabled = self._get_env_bool("OCTOFIESTA_ENABLED", True)
         required_vars = [
             "NAVIDROME_URL",
             "NAVIDROME_USER",
             "NAVIDROME_PASSWORD",
-            "OCTOFIESTA_URL"
         ]
+        if octofiesta_enabled:
+            required_vars.append("OCTOFIESTA_URL")
 
         missing = [var for var in required_vars if not os.getenv(var)]
         if missing:
@@ -225,7 +232,7 @@ class OctoGenEngine:
             logger.error("  NAVIDROME_URL       - Navidrome server URL")
             logger.error("  NAVIDROME_USER      - Navidrome username")
             logger.error("  NAVIDROME_PASSWORD  - Navidrome password")
-            logger.error("  OCTOFIESTA_URL      - Octo-Fiesta server URL")
+            logger.error("  OCTOFIESTA_URL      - Octo-Fiesta server URL (when OCTOFIESTA_ENABLED=true)")
             logger.error("")
             logger.error("See ENV_VARS.md for complete reference")
             sys.exit(1)
@@ -237,7 +244,8 @@ class OctoGenEngine:
                 "password": os.getenv("NAVIDROME_PASSWORD")
             },
             "octofiesta": {
-                "url": os.getenv("OCTOFIESTA_URL")
+                "enabled": octofiesta_enabled,
+                "url": os.getenv("OCTOFIESTA_URL") if octofiesta_enabled else None,
             },
             "ai": {
                 "api_key": os.getenv("AI_API_KEY", ""),
@@ -288,7 +296,8 @@ class OctoGenEngine:
 
         # Log configuration (without secrets)
         logger.info("✓ Navidrome: %s", config['navidrome']['url'])
-        logger.info("✓ Octo-Fiesta: %s", config['octofiesta']['url'])
+        if config['octofiesta']['enabled']:
+            logger.info("✓ Octo-Fiesta: %s", config['octofiesta']['url'])
         if config['lastfm']['enabled']:
             logger.info("✓ Last.fm enabled: %s", config['lastfm']['username'])
         if config['listenbrainz']['enabled']:
@@ -356,10 +365,10 @@ class OctoGenEngine:
         logger.info("✓ Music sources: %s", ", ".join(sources))
         
         # Validate URLs
-        for name, url in [
-            ("Navidrome", self.config["navidrome"]["url"]),
-            ("Octo-Fiesta", self.config["octofiesta"]["url"])
-        ]:
+        services = [("Navidrome", self.config["navidrome"]["url"])]
+        if self.config["octofiesta"]["enabled"]:
+            services.append(("Octo-Fiesta", self.config["octofiesta"]["url"]))
+        for name, url in services:
             if not url:
                 errors.append(f"{name} URL is empty")
             elif not url.startswith(("http://", "https://")):
@@ -606,6 +615,10 @@ class OctoGenEngine:
         if self.dry_run:
             return None
 
+        if self.octo is None:
+            self.stats["fiesta_skipped"] += 1
+            self.stats["songs_failed"] += 1
+            return None
         success, _result = self.octo.search_and_trigger_download(artist, title)
 
         if not success:
@@ -718,6 +731,9 @@ class OctoGenEngine:
                     if d_idx % 5 == 0 or d_idx == 1 or d_idx == len(needs_download):
                         logger.info(" [%s] Download progress: %d/%d", playlist_name, d_idx, len(needs_download))
     
+                    if self.octo is None:
+                        self.stats["fiesta_skipped"] += 1
+                        continue
                     success, _result = self.octo.search_and_trigger_download(artist, title)
                     if success:
                         downloaded_count += 1
@@ -1689,6 +1705,9 @@ CRITICAL RULES:
             logger.info("Songs skipped (low rating): %d", self.stats["songs_skipped_low_rating"])
             logger.info("Songs skipped (duplicate): %d", self.stats["songs_skipped_duplicate"])
             logger.info("Songs failed: %d", self.stats["songs_failed"])
+            if not self.config["octofiesta"]["enabled"]:
+                logger.info("Local-only mode: skipped %d download attempts for missing tracks",
+                            self.stats.get("fiesta_skipped", 0))
             logger.info("=" * 70)
             
             # Record successful run

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -32,14 +32,23 @@ class NavidromeConfig(BaseModel):
 
 class OctoFiestaConfig(BaseModel):
     """Octo-Fiesta server configuration"""
-    url: str = Field(..., description="Octo-Fiesta server URL")
-    
+    enabled: bool = Field(True, description="Enable Octo-Fiesta downloads")
+    url: Optional[str] = Field(default=None, description="Octo-Fiesta server URL")
+
     @field_validator('url')
     @classmethod
     def validate_url(cls, v):
+        if v is None:
+            return v
         if not v.startswith(('http://', 'https://')):
             raise ValueError('URL must start with http:// or https://')
         return v.rstrip('/')
+
+    @model_validator(mode='after')
+    def url_required_when_enabled(self):
+        if self.enabled and not self.url:
+            raise ValueError('OCTOFIESTA_URL is required when OCTOFIESTA_ENABLED=true')
+        return self
 
 
 class AIConfig(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,10 @@
 """Tests for OctoGen configuration loading."""
 
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from octogen.config import load_config_from_env
+from octogen.main import OctoGenEngine
 
 
 # Minimal required env vars so load_config_from_env() doesn't call sys.exit(1)
@@ -82,3 +83,75 @@ class TestOctoFiestaToggle:
                 result = load_config_from_env()
                 mock_exit.assert_called_once_with(1)
         assert result["octofiesta"]["url"] is None
+
+
+class TestHybridDailyMixWithoutOctoFiesta:
+    """Tests for the LLM-clamp behavior of `_generate_hybrid_daily_mix` when
+    Octo-Fiesta is disabled. Without a download path, LLM picks would silently
+    drop out of the playlist, so we skip the LLM call entirely and ship a pure
+    AudioMuse mix.
+    """
+
+    @staticmethod
+    def _make_engine(octo, audiomuse_songs):
+        """Build an engine with just enough state for `_generate_hybrid_daily_mix`."""
+        engine = OctoGenEngine.__new__(OctoGenEngine)
+        engine.octo = octo
+        engine.config = {
+            "audiomuse": {"songs_per_mix": 25, "llm_songs_per_mix": 5},
+        }
+        engine.audiomuse_client = MagicMock()
+        engine.audiomuse_client.generate_playlist.return_value = audiomuse_songs
+        # Sentinel: the LLM helper must not be called when octo is None.
+        engine._generate_llm_songs_for_daily_mix = MagicMock(
+            side_effect=AssertionError("LLM should not be called when octo is None")
+        )
+        return engine
+
+    def test_octo_none_skips_llm_call(self):
+        """When self.octo is None, the LLM helper is never invoked."""
+        audiomuse_picks = [
+            {"artist": "Artist A", "title": f"Song {i}"} for i in range(25)
+        ]
+        engine = self._make_engine(octo=None, audiomuse_songs=audiomuse_picks)
+        songs = engine._generate_hybrid_daily_mix(
+            mix_number=1,
+            genre_focus="rock",
+            characteristics="energetic",
+            top_artists=["A"],
+            top_genres=["rock"],
+            favorited_songs=[{"artist": "A", "title": "X"}],
+            low_rated_songs=None,
+            playlist_name="Daily Mix 1",
+        )
+        # All 25 picks come from AudioMuse, none from LLM.
+        assert len(songs) == 25
+        engine._generate_llm_songs_for_daily_mix.assert_not_called()
+
+    def test_octo_present_calls_llm(self):
+        """When self.octo is set, the LLM helper is invoked as usual."""
+        audiomuse_picks = [
+            {"artist": "Artist A", "title": f"Song {i}"} for i in range(25)
+        ]
+        engine = OctoGenEngine.__new__(OctoGenEngine)
+        engine.octo = MagicMock()  # truthy, not None
+        engine.config = {
+            "audiomuse": {"songs_per_mix": 25, "llm_songs_per_mix": 5},
+        }
+        engine.audiomuse_client = MagicMock()
+        engine.audiomuse_client.generate_playlist.return_value = audiomuse_picks
+        engine._generate_llm_songs_for_daily_mix = MagicMock(return_value=[
+            {"artist": "LLM Artist", "title": f"LLM Song {i}"} for i in range(5)
+        ])
+        songs = engine._generate_hybrid_daily_mix(
+            mix_number=1,
+            genre_focus="rock",
+            characteristics="energetic",
+            top_artists=["A"],
+            top_genres=["rock"],
+            favorited_songs=[{"artist": "A", "title": "X"}],
+            low_rated_songs=None,
+            playlist_name="Daily Mix 1",
+        )
+        assert len(songs) == 30
+        engine._generate_llm_songs_for_daily_mix.assert_called_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,3 +49,36 @@ class TestLoadConfigFromEnvAITimeout:
         with patch.dict(os.environ, {**_REQUIRED_ENV, "AI_REQUEST_TIMEOUT": "30"}):
             config = load_config_from_env()
         assert config["ai"]["request_timeout"] == 30
+
+
+class TestOctoFiestaToggle:
+    """Tests for OCTOFIESTA_ENABLED toggle."""
+
+    def test_enabled_default_true_requires_url(self):
+        """When OCTOFIESTA_ENABLED is unset, OCTOFIESTA_URL must be present (back-compat)."""
+        env = {k: v for k, v in _REQUIRED_ENV.items() if k != "OCTOFIESTA_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("octogen.config.sys.exit") as mock_exit:
+                result = load_config_from_env()
+                mock_exit.assert_called_once_with(1)
+        # Confirm nothing meaningful was returned after the mocked exit
+        assert result["octofiesta"]["url"] is None
+
+    def test_enabled_false_makes_url_optional(self):
+        """OCTOFIESTA_ENABLED=false: OCTOFIESTA_URL is no longer required."""
+        env = {k: v for k, v in _REQUIRED_ENV.items() if k != "OCTOFIESTA_URL"}
+        env["OCTOFIESTA_ENABLED"] = "false"
+        with patch.dict(os.environ, env, clear=True):
+            config = load_config_from_env()
+        assert config["octofiesta"]["enabled"] is False
+        assert config["octofiesta"]["url"] is None
+
+    def test_enabled_true_keeps_url_required(self):
+        """OCTOFIESTA_ENABLED=true (explicit): OCTOFIESTA_URL still required."""
+        env = {k: v for k, v in _REQUIRED_ENV.items() if k != "OCTOFIESTA_URL"}
+        env["OCTOFIESTA_ENABLED"] = "true"
+        with patch.dict(os.environ, env, clear=True):
+            with patch("octogen.config.sys.exit") as mock_exit:
+                result = load_config_from_env()
+                mock_exit.assert_called_once_with(1)
+        assert result["octofiesta"]["url"] is None


### PR DESCRIPTION
Octo-Fiesta is currently the only download trigger in OctoGen, but not every install runs it. This PR makes it optional via `OCTOFIESTA_ENABLED`, so the engine can run "playlist generation only" without requiring `OCTOFIESTA_URL`.

Default behavior is unchanged: `OCTOFIESTA_ENABLED` is treated as true when unset, preserving the existing requirement that `OCTOFIESTA_URL` be present.

## Changes

- **`octogen/models/config_models.py`** — `OctoFiestaConfig.url` is now `Optional[str]`; new `enabled: bool = True` field. Validator only enforces URL shape when `enabled=True`.
- **`octogen/config.py`** / **`octogen/main.py:_load_config_from_env`** — parse `OCTOFIESTA_ENABLED` (default `true`); only require `OCTOFIESTA_URL` when enabled. Both config loaders updated.
- **`octogen/main.py:OctoGenEngine.__init__`** — when disabled, sets `self.octo = None` and logs "Octo-Fiesta: disabled (OCTOFIESTA_ENABLED=false) — local-only mode".
- **`octogen/main.py:_handle_missing_track`** — extracts the missing-track branch into a single helper. When `octo is None`, increments `stats["fiesta_skipped"]` and returns `(False, "fiesta-disabled")` instead of attempting a download.
- **`tests/test_config.py`** — new tests for the toggle: back-compat (unset → URL required), `enabled=false` (URL optional), `enabled=true` (URL still required).
- **`README.md`** / **`docs/ENV_VARS.md`** — document the new variable.
