### PR TITLE
Add Lidarr bridge for missing-track artists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,3 +202,16 @@ TIMEOFDAY_PLAYLIST_SIZE=30
 
 # Auto-regenerate when time period changes (default: true)
 TIMEOFDAY_REFRESH_ON_PERIOD_CHANGE=true
+
+# ============================================================================
+# Lidarr Bridge (OPTIONAL — adds artists for missing tracks)
+# ============================================================================
+# When LIDARR_URL is set, OctoGen pushes missing-track artists to Lidarr after
+# LIDARR_MIN_MISSING encounters. Failures never block playlist generation.
+# LIDARR_URL=http://lidarr:8686
+# LIDARR_API_KEY=
+# LIDARR_QUALITY_PROFILE=Standard
+# LIDARR_METADATA_PROFILE=Standard
+# LIDARR_MIN_MISSING=3
+# LIDARR_ADD_MONITORED=false
+# LIDARR_TAG=octogen

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -1361,6 +1361,50 @@ docker logs octogen | grep "Timezone:"
 
 ---
 
+## Lidarr Bridge
+
+Optional integration: when configured, OctoGen pushes the artist of any missing track to Lidarr after a configurable threshold of misses across runs. Failures never block playlist generation.
+
+### LIDARR_URL
+**Description**: Lidarr server URL. Setting this enables the bridge.
+**Default**: unset (bridge disabled)
+**Format**: `http://hostname:port`
+**Example**:
+```bash
+LIDARR_URL=http://lidarr:8686
+```
+
+### LIDARR_API_KEY
+**Description**: Lidarr API key (Settings → General).
+**Required when**: `LIDARR_URL` is set.
+
+### LIDARR_QUALITY_PROFILE
+**Description**: Lidarr quality profile name (e.g. `Standard`). Resolved to ID at startup.
+**Required when**: `LIDARR_URL` is set.
+
+### LIDARR_METADATA_PROFILE
+**Description**: Lidarr metadata profile name. Resolved to ID at startup.
+**Required when**: `LIDARR_URL` is set.
+
+### LIDARR_MIN_MISSING
+**Description**: Number of missing-track encounters before pushing the artist to Lidarr.
+**Default**: `3`
+**Notes**: Counts persist across runs in OctoGen's SQLite cache.
+
+### LIDARR_ADD_MONITORED
+**Description**: Whether artists added by OctoGen are monitored in Lidarr.
+**Default**: `false` (safer — opt in to downloads via the Lidarr UI)
+
+### LIDARR_TAG
+**Description**: Tag applied to every artist OctoGen adds to Lidarr.
+**Default**: `octogen`
+**Notes**:
+- Created in Lidarr if it doesn't exist.
+- Empty string disables tagging.
+- Lets you filter / bulk-clean OctoGen-added artists later.
+
+---
+
 ## 📊 Variable Summary
 
 | Category | Count | Variables |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ See [AudioMuse-AI Setup](#-audiomuse-ai-setup-optional) below.
 - **Star rating filtering**: Excludes 1-2 star rated songs
 - **Duplicate detection**: No repeated tracks across playlists
 - **Optional Octo-Fiesta integration** — auto-download missing tracks, or run local-only with `OCTOFIESTA_ENABLED=false`
+- **Optional Lidarr bridge** — auto-add missing-track artists to Lidarr after a configurable threshold; safe defaults (unmonitored + tagged for cleanup).
 - **Daily cache**: Efficient library scanning
 - **Async operations**: Fast, parallel processing
 - **LastFM, ListenBrainz & AudioMuse-AI**: Optional integrations

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -117,8 +117,16 @@ class LidarrClient:
         KeyError (missing foreignArtistId in lookup result) to uphold the
         never-raises contract.
         """
-        if self.quality_profile_id is None:
-            return False, "validate() not called"
+        missing = [
+            name for name, value in (
+                ("quality_profile_id", self.quality_profile_id),
+                ("metadata_profile_id", self.metadata_profile_id),
+                ("root_folder_path", self.root_folder_path),
+            )
+            if value is None
+        ]
+        if missing:
+            return False, f"validate() not called or incomplete: missing {', '.join(missing)}"
 
         if self.dry_run:
             logger.info(

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -1,0 +1,100 @@
+"""Lidarr bridge — pushes missing-track artists to Lidarr.
+
+Used by OctoGen when the Lidarr bridge is enabled. Failures during mid-run
+add operations are caught at the call site and never block playlist generation.
+"""
+
+import logging
+from typing import Optional
+
+import requests
+from requests.exceptions import RequestException
+
+
+logger = logging.getLogger(__name__)
+
+
+class LidarrClient:
+    """Client for Lidarr's REST API (artist add + lookup)."""
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str,
+        quality_profile: str,
+        metadata_profile: str,
+        tag: str,
+        monitored: bool,
+        dry_run: bool = False,
+    ):
+        self.url = url.rstrip("/")
+        self.api_key = api_key
+        self.quality_profile_name = quality_profile
+        self.metadata_profile_name = metadata_profile
+        self.tag = tag
+        self.monitored = monitored
+        self.dry_run = dry_run
+
+        self.session = requests.Session()
+        self.session.headers.update({"X-Api-Key": api_key})
+
+        # Resolved during validate()
+        self.quality_profile_id: Optional[int] = None
+        self.metadata_profile_id: Optional[int] = None
+        self.root_folder_path: Optional[str] = None
+        self.tag_id: Optional[int] = None
+
+    # -- validation ---------------------------------------------------------
+
+    def validate(self) -> None:
+        """Resolve profile names → IDs, pick a root folder, ensure tag exists.
+
+        Raises RuntimeError on any failure.
+        """
+        try:
+            self.quality_profile_id = self._resolve_profile(
+                "qualityprofile", self.quality_profile_name, "LIDARR_QUALITY_PROFILE"
+            )
+            self.metadata_profile_id = self._resolve_profile(
+                "metadataprofile", self.metadata_profile_name, "LIDARR_METADATA_PROFILE"
+            )
+            self.root_folder_path = self._pick_root_folder()
+            if self.tag:
+                self.tag_id = self._ensure_tag(self.tag)
+        except RequestException as e:
+            raise RuntimeError(f"Lidarr unreachable at {self.url}: {e}") from e
+
+    def _resolve_profile(self, kind: str, name: str, env_name: str) -> int:
+        resp = self.session.get(f"{self.url}/api/v1/{kind}", timeout=10)
+        resp.raise_for_status()
+        profiles = resp.json()
+        for p in profiles:
+            if p.get("name") == name:
+                return p["id"]
+        available = ", ".join(p.get("name", "?") for p in profiles)
+        raise RuntimeError(
+            f"{env_name}={name!r} not found in Lidarr. Available: [{available}]"
+        )
+
+    def _pick_root_folder(self) -> str:
+        resp = self.session.get(f"{self.url}/api/v1/rootfolder", timeout=10)
+        resp.raise_for_status()
+        folders = resp.json()
+        if not folders:
+            raise RuntimeError(
+                "Lidarr has no root folder configured — add one in Lidarr settings"
+            )
+        return folders[0]["path"]
+
+    def _ensure_tag(self, label: str) -> int:
+        resp = self.session.get(f"{self.url}/api/v1/tag", timeout=10)
+        resp.raise_for_status()
+        for t in resp.json():
+            if t.get("label") == label:
+                return t["id"]
+        # Create it
+        resp = self.session.post(
+            f"{self.url}/api/v1/tag", json={"label": label}, timeout=10
+        )
+        resp.raise_for_status()
+        return resp.json()["id"]

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -98,3 +98,65 @@ class LidarrClient:
         )
         resp.raise_for_status()
         return resp.json()["id"]
+
+    # -- add artist ---------------------------------------------------------
+
+    def add_artist(self, artist_name: str) -> tuple:
+        """Look up artist in MusicBrainz via Lidarr, then add it.
+
+        Returns (success: bool, message: str). Never raises — call site
+        treats this as a side effect of playlist generation.
+        """
+        if self.dry_run:
+            logger.info(
+                "Lidarr (dry-run): would add %s (monitored=%s, tag=%s)",
+                artist_name, self.monitored, self.tag,
+            )
+            return True, "dry-run"
+
+        try:
+            # 1. MusicBrainz lookup via Lidarr
+            resp = self.session.get(
+                f"{self.url}/api/v1/artist/lookup",
+                params={"term": artist_name},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            results = resp.json()
+            if not results:
+                logger.warning("Lidarr: artist %r not found in MusicBrainz", artist_name)
+                return False, f"not found: {artist_name}"
+            match = results[0]
+
+            # 2. Add artist
+            payload = {
+                "foreignArtistId": match["foreignArtistId"],
+                "artistName": match.get("artistName", artist_name),
+                "qualityProfileId": self.quality_profile_id,
+                "metadataProfileId": self.metadata_profile_id,
+                "rootFolderPath": self.root_folder_path,
+                "monitored": self.monitored,
+                "tags": [self.tag_id] if self.tag_id else [],
+                "addOptions": {
+                    "monitor": "all" if self.monitored else "none",
+                    "searchForMissingAlbums": False,
+                },
+            }
+            resp = self.session.post(
+                f"{self.url}/api/v1/artist", json=payload, timeout=15
+            )
+            if resp.status_code == 409:
+                logger.info("Lidarr: %s already exists", artist_name)
+                return True, "already exists"
+            if not resp.ok:
+                logger.warning(
+                    "Lidarr add %s failed (%d): %s",
+                    artist_name, resp.status_code, resp.text[:200],
+                )
+                return False, f"HTTP {resp.status_code}"
+            logger.info("Lidarr: added %s", artist_name)
+            return True, "added"
+
+        except (RequestException, ValueError, KeyError) as e:
+            logger.warning("Lidarr add %s error: %s", artist_name, e)
+            return False, str(e)

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -38,7 +38,6 @@ class LidarrClient:
         self.session = requests.Session()
         self.session.headers.update({"X-Api-Key": api_key})
 
-        # Resolved during validate()
         self.quality_profile_id: Optional[int] = None
         self.metadata_profile_id: Optional[int] = None
         self.root_folder_path: Optional[str] = None
@@ -63,6 +62,10 @@ class LidarrClient:
                 self.tag_id = self._ensure_tag(self.tag)
         except RequestException as e:
             raise RuntimeError(f"Lidarr unreachable at {self.url}: {e}") from e
+        except (KeyError, ValueError, IndexError) as e:
+            raise RuntimeError(
+                f"Lidarr returned unexpected response shape: {type(e).__name__}: {e}"
+            ) from e
 
     def _resolve_profile(self, kind: str, name: str, env_name: str) -> int:
         resp = self.session.get(f"{self.url}/api/v1/{kind}", timeout=10)
@@ -84,7 +87,12 @@ class LidarrClient:
             raise RuntimeError(
                 "Lidarr has no root folder configured — add one in Lidarr settings"
             )
-        return folders[0]["path"]
+        path = folders[0]["path"]
+        if len(folders) > 1:
+            logger.info(
+                "Lidarr: %d root folders configured, using %s", len(folders), path,
+            )
+        return path
 
     def _ensure_tag(self, label: str) -> int:
         resp = self.session.get(f"{self.url}/api/v1/tag", timeout=10)
@@ -92,7 +100,6 @@ class LidarrClient:
         for t in resp.json():
             if t.get("label") == label:
                 return t["id"]
-        # Create it
         resp = self.session.post(
             f"{self.url}/api/v1/tag", json={"label": label}, timeout=10
         )
@@ -106,7 +113,13 @@ class LidarrClient:
 
         Returns (success: bool, message: str). Never raises — call site
         treats this as a side effect of playlist generation.
+        Catches RequestException (network), ValueError (non-JSON body), and
+        KeyError (missing foreignArtistId in lookup result) to uphold the
+        never-raises contract.
         """
+        if self.quality_profile_id is None:
+            return False, "validate() not called"
+
         if self.dry_run:
             logger.info(
                 "Lidarr (dry-run): would add %s (monitored=%s, tag=%s)",
@@ -115,7 +128,6 @@ class LidarrClient:
             return True, "dry-run"
 
         try:
-            # 1. MusicBrainz lookup via Lidarr
             resp = self.session.get(
                 f"{self.url}/api/v1/artist/lookup",
                 params={"term": artist_name},
@@ -128,7 +140,6 @@ class LidarrClient:
                 return False, f"not found: {artist_name}"
             match = results[0]
 
-            # 2. Add artist
             payload = {
                 "foreignArtistId": match["foreignArtistId"],
                 "artistName": match.get("artistName", artist_name),

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -5,7 +5,7 @@ add operations are caught at the call site and never block playlist generation.
 """
 
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 
 import requests
 from requests.exceptions import RequestException
@@ -108,14 +108,11 @@ class LidarrClient:
 
     # -- add artist ---------------------------------------------------------
 
-    def add_artist(self, artist_name: str) -> tuple:
+    def add_artist(self, artist_name: str) -> Tuple[bool, str]:
         """Look up artist in MusicBrainz via Lidarr, then add it.
 
-        Returns (success: bool, message: str). Never raises — call site
-        treats this as a side effect of playlist generation.
-        Catches RequestException (network), ValueError (non-JSON body), and
-        KeyError (missing foreignArtistId in lookup result) to uphold the
-        never-raises contract.
+        Returns (success, message). Never raises — call sites treat this as
+        a side effect of playlist generation.
         """
         missing = [
             name for name, value in (
@@ -177,5 +174,7 @@ class LidarrClient:
             return True, "added"
 
         except (RequestException, ValueError, KeyError) as e:
-            logger.warning("Lidarr add %s error: %s", artist_name, e)
+            logger.warning(
+                "Lidarr add %s error: %s", artist_name, e, exc_info=True,
+            )
             return False, str(e)

--- a/octogen/api/lidarr.py
+++ b/octogen/api/lidarr.py
@@ -173,7 +173,13 @@ class LidarrClient:
             logger.info("Lidarr: added %s", artist_name)
             return True, "added"
 
-        except (RequestException, ValueError, KeyError) as e:
+        except ValueError as e:
+            logger.warning(
+                "Lidarr add %s: invalid JSON response: %s",
+                artist_name, e, exc_info=True,
+            )
+            return False, f"invalid JSON response: {e}"
+        except (RequestException, KeyError) as e:
             logger.warning(
                 "Lidarr add %s error: %s", artist_name, e, exc_info=True,
             )

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional
 from octogen.utils.secrets import load_secret
 from octogen.models.config_models import (
     OctoGenConfig, NavidromeConfig, OctoFiestaConfig, AIConfig,
-    LastFMConfig, ListenBrainzConfig, AudioMuseConfig,
+    LastFMConfig, LidarrConfig, ListenBrainzConfig, AudioMuseConfig,
     SpotifyConfig, DeezerConfig,
     PerformanceConfig, SchedulingConfig, MonitoringConfig,
     WebUIConfig, LoggingConfig
@@ -75,6 +75,16 @@ def load_config_from_env() -> Dict:
             "enabled": os.getenv("LASTFM_ENABLED", "false").lower() == "true",
             "api_key": load_secret("LASTFM_API_KEY"),
             "username": os.getenv("LASTFM_USERNAME"),
+        },
+        "lidarr": {
+            "enabled": bool(load_secret("LIDARR_URL")),
+            "url": load_secret("LIDARR_URL"),
+            "api_key": load_secret("LIDARR_API_KEY"),
+            "min_missing": int(os.getenv("LIDARR_MIN_MISSING", "3")),
+            "add_monitored": os.getenv("LIDARR_ADD_MONITORED", "false").lower() == "true",
+            "tag": os.getenv("LIDARR_TAG", "octogen"),
+            "quality_profile": os.getenv("LIDARR_QUALITY_PROFILE"),
+            "metadata_profile": os.getenv("LIDARR_METADATA_PROFILE"),
         },
         "listenbrainz": {
             "enabled": os.getenv("LISTENBRAINZ_ENABLED", "false").lower() == "true",
@@ -148,6 +158,7 @@ def validate_config(config: Dict) -> Optional[OctoGenConfig]:
             octofiesta=OctoFiestaConfig(**config["octofiesta"]),
             ai=AIConfig(**config["ai"]) if config["ai"]["api_key"] else None,
             lastfm=LastFMConfig(**config["lastfm"]) if config["lastfm"]["enabled"] else None,
+            lidarr=LidarrConfig(**config["lidarr"]) if config["lidarr"]["enabled"] else None,
             listenbrainz=ListenBrainzConfig(**config["listenbrainz"]) if config["listenbrainz"]["enabled"] else None,
             audiomuse=AudioMuseConfig(**config["audiomuse"]) if config["audiomuse"]["enabled"] else None,
             spotify=SpotifyConfig(**config["spotify"]) if config.get("spotify", {}).get("enabled") else None,

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -81,7 +81,7 @@ def load_config_from_env() -> Dict:
             "url": load_secret("LIDARR_URL"),
             "api_key": load_secret("LIDARR_API_KEY"),
             "min_missing": int(os.getenv("LIDARR_MIN_MISSING", "3")),
-            "add_monitored": os.getenv("LIDARR_ADD_MONITORED", "false").lower() == "true",
+            "add_monitored": os.getenv("LIDARR_ADD_MONITORED", "false").lower() in ("true", "1", "yes", "on"),
             "tag": os.getenv("LIDARR_TAG", "octogen"),
             "quality_profile": os.getenv("LIDARR_QUALITY_PROFILE"),
             "metadata_profile": os.getenv("LIDARR_METADATA_PROFILE"),

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -36,6 +36,7 @@ from octogen.api.listenbrainz import ListenBrainzAPI
 from octogen.api.audiomuse import AudioMuseClient
 from octogen.api.spotify import SpotifyImporter
 from octogen.api.deezer import DeezerImporter
+from octogen.api.lidarr import LidarrClient
 from octogen.ai.engine import AIRecommendationEngine, GEMINI_SDK_AVAILABLE
 from octogen.models.tracker import ServiceTracker, RunTracker
 from octogen.web.health import write_health_status
@@ -99,6 +100,29 @@ class OctoGenEngine:
         else:
             self.octo = None
             logger.info("✓ Octo-Fiesta: disabled (OCTOFIESTA_ENABLED=false) — local-only mode")
+
+        if self.config["lidarr"]["enabled"]:
+            self.lidarr = LidarrClient(
+                url=self.config["lidarr"]["url"],
+                api_key=self.config["lidarr"]["api_key"],
+                quality_profile=self.config["lidarr"]["quality_profile"],
+                metadata_profile=self.config["lidarr"]["metadata_profile"],
+                tag=self.config["lidarr"]["tag"],
+                monitored=self.config["lidarr"]["add_monitored"],
+                dry_run=dry_run,
+            )
+            try:
+                self.lidarr.validate()
+                logger.info("✓ Lidarr bridge: %s (monitored=%s, tag=%s, min_missing=%d)",
+                            self.config["lidarr"]["url"],
+                            self.config["lidarr"]["add_monitored"],
+                            self.config["lidarr"]["tag"] or "(none)",
+                            self.config["lidarr"]["min_missing"])
+            except RuntimeError as e:
+                logger.error("Lidarr bridge validation failed: %s", e)
+                sys.exit(1)
+        else:
+            self.lidarr = None
 
         # Initialize AI engine (optional if other services are configured)
         self.ai = None
@@ -199,6 +223,8 @@ class OctoGenEngine:
             "duplicates_prevented": 0,
             "ai_calls": 0,
             "fiesta_skipped": 0,
+            "lidarr_added": 0,
+            "lidarr_below_threshold": 0,
         }
 
         # Track processed songs to avoid duplicates
@@ -272,6 +298,16 @@ class OctoGenEngine:
                 "api_key": os.getenv("LASTFM_API_KEY", ""),
                 "username": os.getenv("LASTFM_USERNAME", "")
             },
+            "lidarr": {
+                "enabled": bool(os.getenv("LIDARR_URL")),
+                "url": os.getenv("LIDARR_URL"),
+                "api_key": load_secret("LIDARR_API_KEY", ""),
+                "min_missing": self._get_env_int("LIDARR_MIN_MISSING", 3),
+                "add_monitored": self._get_env_bool("LIDARR_ADD_MONITORED", False),
+                "tag": os.getenv("LIDARR_TAG", "octogen"),
+                "quality_profile": os.getenv("LIDARR_QUALITY_PROFILE"),
+                "metadata_profile": os.getenv("LIDARR_METADATA_PROFILE"),
+            },
             "listenbrainz": {
                 "enabled": self._get_env_bool("LISTENBRAINZ_ENABLED", False),
                 "username": os.getenv("LISTENBRAINZ_USERNAME", ""),
@@ -313,6 +349,8 @@ class OctoGenEngine:
             logger.info("✓ Spotify import enabled")
         if config['deezer']['enabled']:
             logger.info("✓ Deezer import enabled")
+        if config['lidarr']['enabled']:
+            logger.info("✓ Lidarr bridge enabled: %s", config['lidarr']['url'])
 
         return config
 
@@ -433,6 +471,38 @@ class OctoGenEngine:
             sys.exit(1)
         
         logger.info("✅ Configuration validated successfully")
+
+    def _handle_missing_track(self, artist: str, title: str) -> tuple:
+        """Centralised handling of a track that is missing from the library.
+
+        Returns (fiesta_success, fiesta_result) for compatibility with existing
+        call sites. Lidarr push is a side-effect — failures are logged and
+        ignored.
+        """
+        # 1. Lidarr bridge (independent of fiesta)
+        if self.lidarr is not None:
+            try:
+                count = self.ratings_cache.record_missing_track(artist)
+                threshold = self.config["lidarr"]["min_missing"]
+                if count >= threshold:
+                    pending = set(self.ratings_cache.get_pending_pushes(threshold))
+                    if artist.strip() in pending or any(
+                        a.lower() == artist.strip().lower() for a in pending
+                    ):
+                        success, _msg = self.lidarr.add_artist(artist)
+                        if success:
+                            self.ratings_cache.mark_pushed(artist)
+                            self.stats["lidarr_added"] += 1
+                else:
+                    self.stats["lidarr_below_threshold"] += 1
+            except Exception as e:
+                logger.warning("Lidarr bridge error for %s: %s", artist, e)
+
+        # 2. Fiesta download (existing behaviour)
+        if self.octo is None:
+            self.stats["fiesta_skipped"] += 1
+            return False, "fiesta-disabled"
+        return self.octo.search_and_trigger_download(artist, title)
 
     def _check_run_cooldown(self) -> bool:
         """Check if enough time has passed since last run with smart service-based cooldown.
@@ -619,12 +689,7 @@ class OctoGenEngine:
         if self.dry_run:
             return None
 
-        if self.octo is None:
-            self.stats["fiesta_skipped"] += 1
-            self.stats["songs_failed"] += 1
-            return None
-        success, _result = self.octo.search_and_trigger_download(artist, title)
-
+        success, _result = self._handle_missing_track(artist, title)
         if not success:
             self.stats["songs_failed"] += 1
             return None
@@ -735,10 +800,7 @@ class OctoGenEngine:
                     if d_idx % 5 == 0 or d_idx == 1 or d_idx == len(needs_download):
                         logger.info(" [%s] Download progress: %d/%d", playlist_name, d_idx, len(needs_download))
     
-                    if self.octo is None:
-                        self.stats["fiesta_skipped"] += 1
-                        continue
-                    success, _result = self.octo.search_and_trigger_download(artist, title)
+                    success, _result = self._handle_missing_track(artist, title)
                     if success:
                         downloaded_count += 1
     
@@ -1761,6 +1823,12 @@ CRITICAL RULES:
             if not self.config["octofiesta"]["enabled"]:
                 logger.info("Local-only mode: skipped %d download attempts for missing tracks",
                             self.stats.get("fiesta_skipped", 0))
+            if self.config["lidarr"]["enabled"]:
+                logger.info(
+                    "Lidarr bridge: added %d new artists, tracking %d below threshold",
+                    self.stats.get("lidarr_added", 0),
+                    self.stats.get("lidarr_below_threshold", 0),
+                )
             logger.info("=" * 70)
             
             # Record successful run

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -119,8 +119,15 @@ class OctoGenEngine:
                             self.config["lidarr"]["tag"] or "(none)",
                             self.config["lidarr"]["min_missing"])
             except RuntimeError as e:
-                logger.error("Lidarr bridge validation failed: %s", e)
-                sys.exit(1)
+                # Optional integration: a transient unreachable Lidarr or a
+                # bad profile name should not take down the whole service.
+                # Match the degrade-and-warn pattern used by Last.fm,
+                # ListenBrainz, and AudioMuse.
+                logger.warning(
+                    "Lidarr bridge unavailable: %s. Continuing without it; "
+                    "missing-track artists will not be pushed to Lidarr.", e,
+                )
+                self.lidarr = None
         else:
             self.lidarr = None
 
@@ -495,7 +502,9 @@ class OctoGenEngine:
                     try:
                         success, _msg = self.lidarr.add_artist(artist)
                     except Exception as e:
-                        logger.warning("Lidarr push error for %r: %s", artist, e)
+                        logger.warning(
+                            "Lidarr push error for %r: %s", artist, e, exc_info=True,
+                        )
                     else:
                         if success:
                             self.ratings_cache.mark_pushed(artist)

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -489,25 +489,19 @@ class OctoGenEngine:
                     artist, type(e).__name__, e, exc_info=True,
                 )
             else:
-                if count >= threshold:
-                    pending = set(self.ratings_cache.get_pending_pushes(threshold))
-                    if artist.strip() in pending or any(
-                        a.lower() == artist.strip().lower() for a in pending
-                    ):
-                        try:
-                            success, _msg = self.lidarr.add_artist(artist)
-                        except Exception as e:
-                            logger.warning(
-                                "Lidarr push error for %r: %s", artist, e,
-                            )
-                        else:
-                            if success:
-                                self.ratings_cache.mark_pushed(artist)
-                                self.stats["lidarr_added"] += 1
-                            else:
-                                self.ratings_cache.increment_push_attempt(artist)
-                else:
+                if count < threshold:
                     self.stats["lidarr_below_threshold"] += 1
+                elif self.ratings_cache.is_pending_push(artist, threshold):
+                    try:
+                        success, _msg = self.lidarr.add_artist(artist)
+                    except Exception as e:
+                        logger.warning("Lidarr push error for %r: %s", artist, e)
+                    else:
+                        if success:
+                            self.ratings_cache.mark_pushed(artist)
+                            self.stats["lidarr_added"] += 1
+                        else:
+                            self.ratings_cache.increment_push_attempt(artist)
 
         if self.octo is None:
             self.stats["fiesta_skipped"] += 1

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -232,6 +232,7 @@ class OctoGenEngine:
             "fiesta_skipped": 0,
             "lidarr_added": 0,
             "lidarr_below_threshold": 0,
+            "lidarr_push_failed": 0,
         }
 
         # Track processed songs to avoid duplicates
@@ -487,40 +488,51 @@ class OctoGenEngine:
         ignored.
         """
         if self.lidarr is not None:
-            try:
-                count = self.ratings_cache.record_missing_track(artist)
-                threshold = self.config["lidarr"]["min_missing"]
-            except Exception as e:
-                logger.error(
-                    "Missing-artist DB error for %r (%s): %s",
-                    artist, type(e).__name__, e, exc_info=True,
-                )
-            else:
-                if count < threshold:
-                    self.stats["lidarr_below_threshold"] += 1
-                elif self.ratings_cache.is_pending_push(artist, threshold):
-                    try:
-                        success, _msg = self.lidarr.add_artist(artist)
-                    except Exception as e:
-                        logger.warning(
-                            "Lidarr push error for %r: %s", artist, e, exc_info=True,
-                        )
-                        # Treat exceptions as failed attempts so the retry cap
-                        # (max_attempts) is enforced consistently — otherwise
-                        # a flaky Lidarr would re-attempt every missing-track
-                        # event forever.
-                        self.ratings_cache.increment_push_attempt(artist)
-                    else:
-                        if success:
-                            self.ratings_cache.mark_pushed(artist)
-                            self.stats["lidarr_added"] += 1
-                        else:
-                            self.ratings_cache.increment_push_attempt(artist)
+            self._try_lidarr_push(artist)
 
         if self.octo is None:
             self.stats["fiesta_skipped"] += 1
             return False, "fiesta-disabled"
         return self.octo.search_and_trigger_download(artist, title)
+
+    def _try_lidarr_push(self, artist: str) -> None:
+        """Record the missing-track event and push to Lidarr if threshold met.
+
+        Side-effect only; never raises. Exceptions during push count as failed
+        attempts so the per-artist retry cap is enforced consistently.
+        """
+        try:
+            count = self.ratings_cache.record_missing_track(artist)
+        except Exception as e:
+            logger.error(
+                "Missing-artist DB error for %r (%s): %s",
+                artist, type(e).__name__, e, exc_info=True,
+            )
+            return
+
+        threshold = self.config["lidarr"]["min_missing"]
+        if count < threshold:
+            self.stats["lidarr_below_threshold"] += 1
+            return
+        if not self.ratings_cache.is_pending_push(artist, threshold):
+            return
+
+        try:
+            success, _msg = self.lidarr.add_artist(artist)
+        except Exception as e:
+            logger.warning(
+                "Lidarr push error for %r: %s", artist, e, exc_info=True,
+            )
+            self.ratings_cache.increment_push_attempt(artist)
+            self.stats["lidarr_push_failed"] += 1
+            return
+
+        if success:
+            self.ratings_cache.mark_pushed(artist)
+            self.stats["lidarr_added"] += 1
+        else:
+            self.ratings_cache.increment_push_attempt(artist)
+            self.stats["lidarr_push_failed"] += 1
 
     def _check_run_cooldown(self) -> bool:
         """Check if enough time has passed since last run with smart service-based cooldown.
@@ -1843,8 +1855,9 @@ CRITICAL RULES:
                             self.stats.get("fiesta_skipped", 0))
             if self.config["lidarr"]["enabled"]:
                 logger.info(
-                    "Lidarr bridge: added %d new artists, tracking %d below threshold",
+                    "Lidarr bridge: added %d new artists, %d push failures, tracking %d below threshold",
                     self.stats.get("lidarr_added", 0),
+                    self.stats.get("lidarr_push_failed", 0),
                     self.stats.get("lidarr_below_threshold", 0),
                 )
             logger.info("=" * 70)

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -479,26 +479,36 @@ class OctoGenEngine:
         call sites. Lidarr push is a side-effect — failures are logged and
         ignored.
         """
-        # 1. Lidarr bridge (independent of fiesta)
         if self.lidarr is not None:
             try:
                 count = self.ratings_cache.record_missing_track(artist)
                 threshold = self.config["lidarr"]["min_missing"]
+            except Exception as e:
+                logger.error(
+                    "Missing-artist DB error for %r (%s): %s",
+                    artist, type(e).__name__, e, exc_info=True,
+                )
+            else:
                 if count >= threshold:
                     pending = set(self.ratings_cache.get_pending_pushes(threshold))
                     if artist.strip() in pending or any(
                         a.lower() == artist.strip().lower() for a in pending
                     ):
-                        success, _msg = self.lidarr.add_artist(artist)
-                        if success:
-                            self.ratings_cache.mark_pushed(artist)
-                            self.stats["lidarr_added"] += 1
+                        try:
+                            success, _msg = self.lidarr.add_artist(artist)
+                        except Exception as e:
+                            logger.warning(
+                                "Lidarr push error for %r: %s", artist, e,
+                            )
+                        else:
+                            if success:
+                                self.ratings_cache.mark_pushed(artist)
+                                self.stats["lidarr_added"] += 1
+                            else:
+                                self.ratings_cache.increment_push_attempt(artist)
                 else:
                     self.stats["lidarr_below_threshold"] += 1
-            except Exception as e:
-                logger.warning("Lidarr bridge error for %s: %s", artist, e)
 
-        # 2. Fiesta download (existing behaviour)
         if self.octo is None:
             self.stats["fiesta_skipped"] += 1
             return False, "fiesta-disabled"

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -306,8 +306,8 @@ class OctoGenEngine:
                 "username": os.getenv("LASTFM_USERNAME", "")
             },
             "lidarr": {
-                "enabled": bool(os.getenv("LIDARR_URL")),
-                "url": os.getenv("LIDARR_URL"),
+                "enabled": bool(load_secret("LIDARR_URL", "")),
+                "url": load_secret("LIDARR_URL", "") or None,
                 "api_key": load_secret("LIDARR_API_KEY", ""),
                 "min_missing": self._get_env_int("LIDARR_MIN_MISSING", 3),
                 "add_monitored": self._get_env_bool("LIDARR_ADD_MONITORED", False),
@@ -505,6 +505,11 @@ class OctoGenEngine:
                         logger.warning(
                             "Lidarr push error for %r: %s", artist, e, exc_info=True,
                         )
+                        # Treat exceptions as failed attempts so the retry cap
+                        # (max_attempts) is enforced consistently — otherwise
+                        # a flaky Lidarr would re-attempt every missing-track
+                        # event forever.
+                        self.ratings_cache.increment_push_attempt(artist)
                     else:
                         if success:
                             self.ratings_cache.mark_pushed(artist)

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -181,8 +181,10 @@ class LidarrConfig(BaseModel):
     url: Optional[str] = None
     api_key: Optional[str] = None
     min_missing: int = Field(default=3, ge=1)
-    add_monitored: bool = False
-    """When True, Lidarr addOptions.monitor='all'; when False, 'none'."""
+    add_monitored: bool = Field(
+        default=False,
+        description="When True, Lidarr addOptions.monitor='all'; when False, 'none'.",
+    )
     tag: str = "octogen"
     quality_profile: Optional[str] = None
     metadata_profile: Optional[str] = None

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -175,12 +175,49 @@ class LoggingConfig(BaseModel):
         return v.lower()
 
 
+class LidarrConfig(BaseModel):
+    """Lidarr bridge configuration"""
+    enabled: bool = False
+    url: Optional[str] = None
+    api_key: Optional[str] = None
+    min_missing: int = Field(default=3, ge=1)
+    add_monitored: bool = False
+    tag: str = "octogen"
+    quality_profile: Optional[str] = None
+    metadata_profile: Optional[str] = None
+
+    @field_validator('url')
+    @classmethod
+    def validate_url(cls, v):
+        if v is None:
+            return v
+        if not v.startswith(('http://', 'https://')):
+            raise ValueError('URL must start with http:// or https://')
+        return v.rstrip('/')
+
+    @model_validator(mode='after')
+    def required_when_enabled(self):
+        if self.enabled:
+            missing = [name for name, val in [
+                ("LIDARR_URL", self.url),
+                ("LIDARR_API_KEY", self.api_key),
+                ("LIDARR_QUALITY_PROFILE", self.quality_profile),
+                ("LIDARR_METADATA_PROFILE", self.metadata_profile),
+            ] if not val]
+            if missing:
+                raise ValueError(
+                    f"Lidarr bridge enabled but missing: {', '.join(missing)}"
+                )
+        return self
+
+
 class OctoGenConfig(BaseModel):
     """Main OctoGen configuration"""
     navidrome: NavidromeConfig
     octofiesta: OctoFiestaConfig
     ai: Optional[AIConfig] = None
     lastfm: Optional[LastFMConfig] = None
+    lidarr: Optional[LidarrConfig] = None
     listenbrainz: Optional[ListenBrainzConfig] = None
     audiomuse: Optional[AudioMuseConfig] = None
     spotify: Optional[SpotifyConfig] = None

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -182,6 +182,7 @@ class LidarrConfig(BaseModel):
     api_key: Optional[str] = None
     min_missing: int = Field(default=3, ge=1)
     add_monitored: bool = False
+    """When True, Lidarr addOptions.monitor='all'; when False, 'none'."""
     tag: str = "octogen"
     quality_profile: Optional[str] = None
     metadata_profile: Optional[str] = None

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -60,18 +60,15 @@ class RatingsCache:
                     push_attempt_count INTEGER NOT NULL DEFAULT 0
                 )
             """)
-            # Idempotent: column may already exist on pre-existing DBs.
-            try:
+            existing = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(missing_artists)")
+            }
+            if "push_attempt_count" not in existing:
                 conn.execute(
                     "ALTER TABLE missing_artists ADD COLUMN "
                     "push_attempt_count INTEGER NOT NULL DEFAULT 0"
                 )
-            except sqlite3.OperationalError as e:
-                if "duplicate column" not in str(e).lower():
-                    logger.error(
-                        "missing_artists migration failed: %s", e, exc_info=True,
-                    )
-                    raise
             conn.commit()
 
     def get_last_scan_date(self) -> Optional[str]:
@@ -158,25 +155,17 @@ class RatingsCache:
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute(
-                "SELECT missing_count FROM missing_artists WHERE artist=?",
-                (key,),
+                """INSERT INTO missing_artists
+                   (artist, artist_display, missing_count, first_seen, last_seen)
+                   VALUES (?, ?, 1, ?, ?)
+                   ON CONFLICT(artist) DO UPDATE SET
+                     missing_count = missing_count + 1,
+                     last_seen = excluded.last_seen
+                   RETURNING missing_count""",
+                (key, display, now, now),
             ).fetchone()
-            if row:
-                new_count = row[0] + 1
-                conn.execute(
-                    "UPDATE missing_artists SET missing_count=?, last_seen=? WHERE artist=?",
-                    (new_count, now, key),
-                )
-            else:
-                new_count = 1
-                conn.execute(
-                    """INSERT INTO missing_artists
-                       (artist, artist_display, missing_count, first_seen, last_seen)
-                       VALUES (?, ?, 1, ?, ?)""",
-                    (key, display, now, now),
-                )
             conn.commit()
-        return new_count
+        return row[0]
 
     def mark_pushed(self, artist: str) -> None:
         """Mark an artist as pushed to Lidarr."""
@@ -203,7 +192,13 @@ class RatingsCache:
                 (key,),
             ).fetchone()
             conn.commit()
-        return row[0] if row else 0
+        if row is None:
+            logger.warning(
+                "increment_push_attempt called for unknown artist %r — no row updated",
+                artist,
+            )
+            return 0
+        return row[0]
 
     def get_pending_pushes(self, threshold: int, max_attempts: int = 5) -> List[str]:
         """Return display names of artists at/above threshold, not yet pushed,

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -56,9 +56,17 @@ class RatingsCache:
                     missing_count INTEGER NOT NULL DEFAULT 0,
                     first_seen TEXT NOT NULL,
                     last_seen TEXT NOT NULL,
-                    pushed_to_lidarr TEXT
+                    pushed_to_lidarr TEXT,
+                    push_attempt_count INTEGER NOT NULL DEFAULT 0
                 )
             """)
+            try:
+                conn.execute(
+                    "ALTER TABLE missing_artists ADD COLUMN "
+                    "push_attempt_count INTEGER NOT NULL DEFAULT 0"
+                )
+            except sqlite3.OperationalError:
+                pass
             conn.commit()
 
     def get_last_scan_date(self) -> Optional[str]:
@@ -176,12 +184,31 @@ class RatingsCache:
             )
             conn.commit()
 
-    def get_pending_pushes(self, threshold: int) -> List[str]:
-        """Return display names of artists at/above threshold and not yet pushed."""
+    def increment_push_attempt(self, artist: str) -> int:
+        """Record a failed push attempt; return new attempt count."""
+        key = self._normalize_artist(artist)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE missing_artists SET push_attempt_count = push_attempt_count + 1 "
+                "WHERE artist=?",
+                (key,),
+            )
+            row = conn.execute(
+                "SELECT push_attempt_count FROM missing_artists WHERE artist=?",
+                (key,),
+            ).fetchone()
+            conn.commit()
+        return row[0] if row else 0
+
+    def get_pending_pushes(self, threshold: int, max_attempts: int = 5) -> List[str]:
+        """Return display names of artists at/above threshold, not yet pushed,
+        and below max failed attempts."""
         with sqlite3.connect(self.db_path) as conn:
             rows = conn.execute(
                 """SELECT artist_display FROM missing_artists
-                   WHERE missing_count >= ? AND pushed_to_lidarr IS NULL""",
-                (threshold,),
+                   WHERE missing_count >= ?
+                     AND pushed_to_lidarr IS NULL
+                     AND push_attempt_count < ?""",
+                (threshold, max_attempts),
             ).fetchall()
         return [r[0] for r in rows]

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -2,7 +2,7 @@
 
 import sqlite3
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Optional
 
@@ -142,7 +142,7 @@ class RatingsCache:
         """
         key = self._normalize_artist(artist)
         display = artist.strip()
-        now = datetime.utcnow().isoformat(timespec="seconds")
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         with sqlite3.connect(self.db_path) as conn:
             row = conn.execute(
                 "SELECT missing_count FROM missing_artists WHERE artist=?",
@@ -168,7 +168,7 @@ class RatingsCache:
     def mark_pushed(self, artist: str) -> None:
         """Mark an artist as pushed to Lidarr."""
         key = self._normalize_artist(artist)
-        now = datetime.utcnow().isoformat(timespec="seconds")
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         with sqlite3.connect(self.db_path) as conn:
             conn.execute(
                 "UPDATE missing_artists SET pushed_to_lidarr=? WHERE artist=?",

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -60,6 +60,9 @@ class RatingsCache:
                     push_attempt_count INTEGER NOT NULL DEFAULT 0
                 )
             """)
+            # Idempotent migration for DBs created before push_attempt_count
+            # existed in CREATE TABLE — duplicate-column raises OperationalError
+            # which we swallow.
             try:
                 conn.execute(
                     "ALTER TABLE missing_artists ADD COLUMN "
@@ -212,3 +215,19 @@ class RatingsCache:
                 (threshold, max_attempts),
             ).fetchall()
         return [r[0] for r in rows]
+
+    def is_pending_push(
+        self, artist: str, threshold: int, max_attempts: int = 5
+    ) -> bool:
+        """True if `artist` is at/above threshold, not yet pushed, and below max attempts."""
+        key = self._normalize_artist(artist)
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                """SELECT 1 FROM missing_artists
+                   WHERE artist = ?
+                     AND missing_count >= ?
+                     AND pushed_to_lidarr IS NULL
+                     AND push_attempt_count < ?""",
+                (key, threshold, max_attempts),
+            ).fetchone()
+        return row is not None

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -49,6 +49,16 @@ class RatingsCache:
                     value TEXT NOT NULL
                 )
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS missing_artists (
+                    artist TEXT PRIMARY KEY,
+                    artist_display TEXT NOT NULL,
+                    missing_count INTEGER NOT NULL DEFAULT 0,
+                    first_seen TEXT NOT NULL,
+                    last_seen TEXT NOT NULL,
+                    pushed_to_lidarr TEXT
+                )
+            """)
             conn.commit()
 
     def get_last_scan_date(self) -> Optional[str]:
@@ -119,3 +129,59 @@ class RatingsCache:
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("DELETE FROM ratings")
             conn.commit()
+
+    @staticmethod
+    def _normalize_artist(name: str) -> str:
+        return name.strip().lower()
+
+    def record_missing_track(self, artist: str) -> int:
+        """Record that a track by `artist` was missing.
+
+        Increments the count for that artist (case-insensitive, whitespace-trimmed).
+        Returns the new count.
+        """
+        key = self._normalize_artist(artist)
+        display = artist.strip()
+        now = datetime.utcnow().isoformat(timespec="seconds")
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT missing_count FROM missing_artists WHERE artist=?",
+                (key,),
+            ).fetchone()
+            if row:
+                new_count = row[0] + 1
+                conn.execute(
+                    "UPDATE missing_artists SET missing_count=?, last_seen=? WHERE artist=?",
+                    (new_count, now, key),
+                )
+            else:
+                new_count = 1
+                conn.execute(
+                    """INSERT INTO missing_artists
+                       (artist, artist_display, missing_count, first_seen, last_seen)
+                       VALUES (?, ?, 1, ?, ?)""",
+                    (key, display, now, now),
+                )
+            conn.commit()
+        return new_count
+
+    def mark_pushed(self, artist: str) -> None:
+        """Mark an artist as pushed to Lidarr."""
+        key = self._normalize_artist(artist)
+        now = datetime.utcnow().isoformat(timespec="seconds")
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "UPDATE missing_artists SET pushed_to_lidarr=? WHERE artist=?",
+                (now, key),
+            )
+            conn.commit()
+
+    def get_pending_pushes(self, threshold: int) -> List[str]:
+        """Return display names of artists at/above threshold and not yet pushed."""
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """SELECT artist_display FROM missing_artists
+                   WHERE missing_count >= ? AND pushed_to_lidarr IS NULL""",
+                (threshold,),
+            ).fetchall()
+        return [r[0] for r in rows]

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -61,15 +61,20 @@ class RatingsCache:
                 )
             """)
             # Idempotent migration for DBs created before push_attempt_count
-            # existed in CREATE TABLE — duplicate-column raises OperationalError
-            # which we swallow.
+            # existed in CREATE TABLE. Only swallow the expected
+            # "duplicate column" error; any other OperationalError signals a
+            # real schema/IO problem and must surface.
             try:
                 conn.execute(
                     "ALTER TABLE missing_artists ADD COLUMN "
                     "push_attempt_count INTEGER NOT NULL DEFAULT 0"
                 )
-            except sqlite3.OperationalError:
-                pass
+            except sqlite3.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    logger.error(
+                        "missing_artists migration failed: %s", e, exc_info=True,
+                    )
+                    raise
             conn.commit()
 
     def get_last_scan_date(self) -> Optional[str]:

--- a/octogen/storage/cache.py
+++ b/octogen/storage/cache.py
@@ -60,10 +60,7 @@ class RatingsCache:
                     push_attempt_count INTEGER NOT NULL DEFAULT 0
                 )
             """)
-            # Idempotent migration for DBs created before push_attempt_count
-            # existed in CREATE TABLE. Only swallow the expected
-            # "duplicate column" error; any other OperationalError signals a
-            # real schema/IO problem and must surface.
+            # Idempotent: column may already exist on pre-existing DBs.
             try:
                 conn.execute(
                     "ALTER TABLE missing_artists ADD COLUMN "

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -351,6 +351,10 @@ def check_lidarr() -> Dict[str, Any]:
                 "healthy": False
             }
 
+        # Normalize trailing slash to mirror LidarrClient.url and avoid
+        # accidental "//api/v1/..." paths.
+        url = url.rstrip("/")
+
         response = requests.get(
             f"{url}/api/v1/system/status",
             headers={"X-Api-Key": api_key},
@@ -383,10 +387,10 @@ def check_lidarr() -> Dict[str, Any]:
             "healthy": False
         }
     except Exception as e:
-        logger.error("Error checking Lidarr: %s", e)
+        logger.error("Error checking Lidarr: %s", e, exc_info=True)
         return {
             "status": "error",
-            "message": "Unexpected error",
+            "message": str(e),
             "healthy": False
         }
 

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -351,8 +351,6 @@ def check_lidarr() -> Dict[str, Any]:
                 "healthy": False
             }
 
-        # Normalize trailing slash to mirror LidarrClient.url and avoid
-        # accidental "//api/v1/..." paths.
         url = url.rstrip("/")
 
         response = requests.get(

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -331,6 +331,70 @@ def check_lastfm() -> Dict[str, Any]:
         }
 
 
+def check_lidarr() -> Dict[str, Any]:
+    """Check Lidarr bridge service.
+
+    Returns:
+        Dict with status and message
+    """
+    try:
+        url = os.getenv("LIDARR_URL")
+        api_key = os.getenv("LIDARR_API_KEY")
+
+        if not url:
+            return {
+                "status": "disabled",
+                "message": "Not enabled",
+                "healthy": False
+            }
+
+        if not api_key:
+            return {
+                "status": "error",
+                "message": "Missing configuration",
+                "healthy": False
+            }
+
+        response = requests.get(
+            f"{url}/api/v1/system/status",
+            headers={"X-Api-Key": api_key},
+            timeout=5
+        )
+
+        if response.status_code == 200:
+            return {
+                "status": "healthy",
+                "message": "Connected",
+                "healthy": True
+            }
+
+        return {
+            "status": "warning",
+            "message": f"HTTP {response.status_code}",
+            "healthy": False
+        }
+
+    except requests.exceptions.Timeout:
+        return {
+            "status": "error",
+            "message": "Connection timeout",
+            "healthy": False
+        }
+    except requests.exceptions.ConnectionError:
+        return {
+            "status": "error",
+            "message": "Connection refused",
+            "healthy": False
+        }
+    except Exception as e:
+        logger.error(f"Error checking Lidarr: {e}")
+        return {
+            "status": "error",
+            "message": str(e),
+            "healthy": False
+        }
+
+
 def check_listenbrainz() -> Dict[str, Any]:
     """Check ListenBrainz service status.
     
@@ -385,6 +449,7 @@ def get_all_services() -> Dict[str, Dict[str, Any]]:
         "ai": check_ai(),
         "audiomuse": check_audiomuse(),
         "lastfm": check_lastfm(),
+        "lidarr": check_lidarr(),
         "listenbrainz": check_listenbrainz()
     }
 

--- a/octogen/web/health.py
+++ b/octogen/web/health.py
@@ -332,14 +332,10 @@ def check_lastfm() -> Dict[str, Any]:
 
 
 def check_lidarr() -> Dict[str, Any]:
-    """Check Lidarr bridge service.
-
-    Returns:
-        Dict with status and message
-    """
+    """Probe Lidarr's /api/v1/system/status endpoint."""
     try:
-        url = os.getenv("LIDARR_URL")
-        api_key = os.getenv("LIDARR_API_KEY")
+        url = load_secret("LIDARR_URL")
+        api_key = load_secret("LIDARR_API_KEY")
 
         if not url:
             return {
@@ -387,10 +383,10 @@ def check_lidarr() -> Dict[str, Any]:
             "healthy": False
         }
     except Exception as e:
-        logger.error(f"Error checking Lidarr: {e}")
+        logger.error("Error checking Lidarr: %s", e)
         return {
             "status": "error",
-            "message": str(e),
+            "message": "Unexpected error",
             "healthy": False
         }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from octogen.config import load_config_from_env
 from octogen.main import OctoGenEngine
 
@@ -59,11 +61,10 @@ class TestOctoFiestaToggle:
         """When OCTOFIESTA_ENABLED is unset, OCTOFIESTA_URL must be present (back-compat)."""
         env = {k: v for k, v in _REQUIRED_ENV.items() if k != "OCTOFIESTA_URL"}
         with patch.dict(os.environ, env, clear=True):
-            with patch("octogen.config.sys.exit") as mock_exit:
-                result = load_config_from_env()
+            with patch("octogen.config.sys.exit", side_effect=SystemExit(1)) as mock_exit:
+                with pytest.raises(SystemExit):
+                    load_config_from_env()
                 mock_exit.assert_called_once_with(1)
-        # Confirm nothing meaningful was returned after the mocked exit
-        assert result["octofiesta"]["url"] is None
 
 
 class TestLidarrConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,57 @@ class TestOctoFiestaToggle:
         # Confirm nothing meaningful was returned after the mocked exit
         assert result["octofiesta"]["url"] is None
 
+
+class TestLidarrConfig:
+    """Tests for Lidarr bridge config loading."""
+
+    def test_lidarr_url_unset_means_disabled(self):
+        with patch.dict(os.environ, _REQUIRED_ENV, clear=True):
+            config = load_config_from_env()
+        assert config["lidarr"]["enabled"] is False
+
+    def test_lidarr_url_set_enables_bridge(self):
+        env = {
+            **_REQUIRED_ENV,
+            "LIDARR_URL": "http://lidarr.test",
+            "LIDARR_API_KEY": "abc",
+            "LIDARR_QUALITY_PROFILE": "Standard",
+            "LIDARR_METADATA_PROFILE": "Standard",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_config_from_env()
+        assert config["lidarr"]["enabled"] is True
+        assert config["lidarr"]["url"] == "http://lidarr.test"
+        assert config["lidarr"]["min_missing"] == 3  # default
+        assert config["lidarr"]["add_monitored"] is False
+        assert config["lidarr"]["tag"] == "octogen"
+
+    def test_lidarr_min_missing_override(self):
+        env = {
+            **_REQUIRED_ENV,
+            "LIDARR_URL": "http://lidarr.test",
+            "LIDARR_API_KEY": "abc",
+            "LIDARR_QUALITY_PROFILE": "Standard",
+            "LIDARR_METADATA_PROFILE": "Standard",
+            "LIDARR_MIN_MISSING": "10",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_config_from_env()
+        assert config["lidarr"]["min_missing"] == 10
+
+    def test_lidarr_empty_tag_disables_tagging(self):
+        env = {
+            **_REQUIRED_ENV,
+            "LIDARR_URL": "http://lidarr.test",
+            "LIDARR_API_KEY": "abc",
+            "LIDARR_QUALITY_PROFILE": "Standard",
+            "LIDARR_METADATA_PROFILE": "Standard",
+            "LIDARR_TAG": "",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = load_config_from_env()
+        assert config["lidarr"]["tag"] == ""
+
     def test_enabled_false_makes_url_optional(self):
         """OCTOFIESTA_ENABLED=false: OCTOFIESTA_URL is no longer required."""
         env = {k: v for k, v in _REQUIRED_ENV.items() if k != "OCTOFIESTA_URL"}

--- a/tests/test_handle_missing_track.py
+++ b/tests/test_handle_missing_track.py
@@ -1,0 +1,96 @@
+"""Integration tests for OctoGenEngine._handle_missing_track threshold wiring.
+
+Constructs a bare engine via __new__ to bypass network-heavy __init__, then
+wires only the attributes _handle_missing_track touches.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from octogen.main import OctoGenEngine
+from octogen.storage.cache import RatingsCache
+
+
+def _engine_with(cache, lidarr=None, octo=None, min_missing=3):
+    engine = OctoGenEngine.__new__(OctoGenEngine)
+    engine.ratings_cache = cache
+    engine.lidarr = lidarr
+    engine.octo = octo
+    engine.config = {"lidarr": {"min_missing": min_missing}}
+    engine.stats = {"lidarr_added": 0, "lidarr_below_threshold": 0, "fiesta_skipped": 0}
+    return engine
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return RatingsCache(tmp_path / "test.db")
+
+
+def test_below_threshold_increments_counter_no_lidarr_call(cache):
+    lidarr = MagicMock()
+    engine = _engine_with(cache, lidarr=lidarr, min_missing=3)
+
+    engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert engine.stats["lidarr_below_threshold"] == 1
+    assert engine.stats["lidarr_added"] == 0
+    lidarr.add_artist.assert_not_called()
+
+
+def test_at_threshold_pushes_to_lidarr_and_marks_pushed(cache):
+    lidarr = MagicMock()
+    lidarr.add_artist.return_value = (True, "added")
+    engine = _engine_with(cache, lidarr=lidarr, min_missing=3)
+
+    for _ in range(3):
+        engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    lidarr.add_artist.assert_called_once_with("Foo Fighters")
+    assert engine.stats["lidarr_added"] == 1
+    assert cache.get_pending_pushes(threshold=3) == []
+
+
+def test_lidarr_disabled_skips_bridge_entirely(cache):
+    engine = _engine_with(cache, lidarr=None, min_missing=3)
+
+    for _ in range(5):
+        engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert engine.stats["lidarr_added"] == 0
+    assert engine.stats["lidarr_below_threshold"] == 0
+
+
+def test_lidarr_failure_does_not_mark_pushed_or_count_added(cache):
+    lidarr = MagicMock()
+    lidarr.add_artist.return_value = (False, "HTTP 500")
+    engine = _engine_with(cache, lidarr=lidarr, min_missing=3)
+
+    for _ in range(3):
+        engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    lidarr.add_artist.assert_called_once()
+    assert engine.stats["lidarr_added"] == 0
+    assert cache.get_pending_pushes(threshold=3) == ["Foo Fighters"]
+
+
+def test_octofiesta_disabled_increments_skip_counter(cache):
+    engine = _engine_with(cache, lidarr=None, octo=None, min_missing=3)
+
+    success, msg = engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert success is False
+    assert msg == "fiesta-disabled"
+    assert engine.stats["fiesta_skipped"] == 1
+
+
+def test_octofiesta_called_when_enabled(cache):
+    octo = MagicMock()
+    octo.search_and_trigger_download.return_value = (True, "downloaded")
+    engine = _engine_with(cache, lidarr=None, octo=octo, min_missing=3)
+
+    success, msg = engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    octo.search_and_trigger_download.assert_called_once_with("Foo Fighters", "Everlong")
+    assert success is True
+    assert engine.stats["fiesta_skipped"] == 0

--- a/tests/test_handle_missing_track.py
+++ b/tests/test_handle_missing_track.py
@@ -94,3 +94,60 @@ def test_octofiesta_called_when_enabled(cache):
     octo.search_and_trigger_download.assert_called_once_with("Foo Fighters", "Everlong")
     assert success is True
     assert engine.stats["fiesta_skipped"] == 0
+
+
+def test_lidarr_active_with_octofiesta_disabled(cache):
+    lidarr = MagicMock()
+    lidarr.add_artist.return_value = (True, "added")
+    engine = _engine_with(cache, lidarr=lidarr, octo=None, min_missing=3)
+
+    for _ in range(3):
+        result = engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    lidarr.add_artist.assert_called_once_with("Foo Fighters")
+    assert engine.stats["lidarr_added"] == 1
+    assert engine.stats["fiesta_skipped"] == 3
+    assert result == (False, "fiesta-disabled")
+
+
+def test_failed_push_does_not_retry_after_max_attempts(cache):
+    lidarr = MagicMock()
+    lidarr.add_artist.return_value = (False, "HTTP 500")
+    engine = _engine_with(cache, lidarr=lidarr, min_missing=3)
+
+    for _ in range(3 + 5):
+        engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert lidarr.add_artist.call_count == 5
+    assert engine.stats["lidarr_added"] == 0
+
+
+def test_db_error_during_record_logs_and_continues(cache, caplog):
+    import logging
+    bad_cache = MagicMock()
+    bad_cache.record_missing_track.side_effect = RuntimeError("disk full")
+    octo = MagicMock()
+    octo.search_and_trigger_download.return_value = (True, "downloaded")
+    engine = _engine_with(bad_cache, lidarr=MagicMock(), octo=octo, min_missing=3)
+
+    with caplog.at_level(logging.ERROR):
+        success, _msg = engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert success is True
+    assert any("DB error" in rec.message for rec in caplog.records)
+
+
+def test_lidarr_push_exception_logged_and_continues(cache, caplog):
+    import logging
+    lidarr = MagicMock()
+    lidarr.add_artist.side_effect = RuntimeError("unexpected")
+    octo = MagicMock()
+    octo.search_and_trigger_download.return_value = (True, "downloaded")
+    engine = _engine_with(cache, lidarr=lidarr, octo=octo, min_missing=3)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            engine._handle_missing_track("Foo Fighters", "Everlong")
+
+    assert any("Lidarr push error" in rec.message for rec in caplog.records)
+    assert engine.stats["lidarr_added"] == 0

--- a/tests/test_handle_missing_track.py
+++ b/tests/test_handle_missing_track.py
@@ -18,7 +18,12 @@ def _engine_with(cache, lidarr=None, octo=None, min_missing=3):
     engine.lidarr = lidarr
     engine.octo = octo
     engine.config = {"lidarr": {"min_missing": min_missing}}
-    engine.stats = {"lidarr_added": 0, "lidarr_below_threshold": 0, "fiesta_skipped": 0}
+    engine.stats = {
+        "lidarr_added": 0,
+        "lidarr_below_threshold": 0,
+        "lidarr_push_failed": 0,
+        "fiesta_skipped": 0,
+    }
     return engine
 
 
@@ -71,6 +76,7 @@ def test_lidarr_failure_does_not_mark_pushed_or_count_added(cache):
 
     lidarr.add_artist.assert_called_once()
     assert engine.stats["lidarr_added"] == 0
+    assert engine.stats["lidarr_push_failed"] == 1
     assert cache.get_pending_pushes(threshold=3) == ["Foo Fighters"]
 
 

--- a/tests/test_health_lidarr.py
+++ b/tests/test_health_lidarr.py
@@ -1,0 +1,69 @@
+"""Tests for the Lidarr health probe."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from octogen.web.health import check_lidarr
+
+
+@pytest.fixture(autouse=True)
+def clear_lidarr_env(monkeypatch):
+    monkeypatch.delenv("LIDARR_URL", raising=False)
+    monkeypatch.delenv("LIDARR_API_KEY", raising=False)
+
+
+def test_check_lidarr_disabled_when_no_url():
+    assert check_lidarr()["status"] == "disabled"
+
+
+def test_check_lidarr_error_when_url_set_but_no_key(monkeypatch):
+    monkeypatch.setenv("LIDARR_URL", "http://lidarr.test")
+    result = check_lidarr()
+    assert result["status"] == "error"
+    assert "configuration" in result["message"].lower()
+
+
+def test_check_lidarr_healthy_when_status_endpoint_ok(monkeypatch):
+    monkeypatch.setenv("LIDARR_URL", "http://lidarr.test")
+    monkeypatch.setenv("LIDARR_API_KEY", "abc123")
+    resp = MagicMock(status_code=200)
+    with patch("octogen.web.health.requests.get", return_value=resp):
+        result = check_lidarr()
+    assert result["status"] == "healthy"
+    assert result["healthy"] is True
+
+
+def test_check_lidarr_warning_on_non_200(monkeypatch):
+    monkeypatch.setenv("LIDARR_URL", "http://lidarr.test")
+    monkeypatch.setenv("LIDARR_API_KEY", "abc123")
+    resp = MagicMock(status_code=503)
+    with patch("octogen.web.health.requests.get", return_value=resp):
+        result = check_lidarr()
+    assert result["status"] == "warning"
+    assert "503" in result["message"]
+
+
+def test_check_lidarr_error_on_connection_refused(monkeypatch):
+    monkeypatch.setenv("LIDARR_URL", "http://lidarr.test")
+    monkeypatch.setenv("LIDARR_API_KEY", "abc123")
+    with patch(
+        "octogen.web.health.requests.get",
+        side_effect=requests.exceptions.ConnectionError(),
+    ):
+        result = check_lidarr()
+    assert result["status"] == "error"
+    assert "refused" in result["message"].lower()
+
+
+def test_check_lidarr_error_on_timeout(monkeypatch):
+    monkeypatch.setenv("LIDARR_URL", "http://lidarr.test")
+    monkeypatch.setenv("LIDARR_API_KEY", "abc123")
+    with patch(
+        "octogen.web.health.requests.get",
+        side_effect=requests.exceptions.Timeout(),
+    ):
+        result = check_lidarr()
+    assert result["status"] == "error"
+    assert "timeout" in result["message"].lower()

--- a/tests/test_lidarr.py
+++ b/tests/test_lidarr.py
@@ -81,3 +81,100 @@ class TestValidate:
             ]
             with pytest.raises(RuntimeError, match="root folder"):
                 client.validate()
+
+
+def _validated_client(monitored=False, dry_run=False):
+    c = LidarrClient(
+        url="http://lidarr.test",
+        api_key="abc123",
+        quality_profile="Standard",
+        metadata_profile="Standard",
+        tag="octogen",
+        monitored=monitored,
+        dry_run=dry_run,
+    )
+    # Skip the network round-trip
+    c.quality_profile_id = 1
+    c.metadata_profile_id = 2
+    c.root_folder_path = "/music"
+    c.tag_id = 7
+    return c
+
+
+class TestAddArtist:
+
+    def test_add_artist_success_payload(self):
+        client = _validated_client(monitored=False)
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.return_value = _mock_response(200, [
+                {"foreignArtistId": "mb-001", "artistName": "Foo Fighters"}
+            ])
+            mock_post.return_value = _mock_response(201, {"id": 99})
+
+            success, msg = client.add_artist("Foo Fighters")
+
+        assert success is True
+        assert mock_post.call_count == 1
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["foreignArtistId"] == "mb-001"
+        assert sent["qualityProfileId"] == 1
+        assert sent["metadataProfileId"] == 2
+        assert sent["rootFolderPath"] == "/music"
+        assert sent["monitored"] is False
+        assert sent["tags"] == [7]
+        assert sent["addOptions"]["searchForMissingAlbums"] is False
+
+    def test_add_artist_409_treated_as_success(self):
+        client = _validated_client()
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.return_value = _mock_response(200, [
+                {"foreignArtistId": "mb-001", "artistName": "Foo Fighters"}
+            ])
+            mock_post.return_value = _mock_response(409, {"message": "already exists"})
+
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is True
+        assert "already" in msg.lower()
+
+    def test_add_artist_5xx_returns_failure_no_raise(self):
+        client = _validated_client()
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.return_value = _mock_response(200, [
+                {"foreignArtistId": "mb-001", "artistName": "Foo Fighters"}
+            ])
+            mock_post.return_value = _mock_response(500)
+
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is False
+
+    def test_add_artist_lookup_empty_returns_failure(self):
+        client = _validated_client()
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
+            mock_get.return_value = _mock_response(200, [])
+            success, msg = client.add_artist("Nonexistent")
+        assert success is False
+        assert "not found" in msg.lower()
+
+    def test_add_artist_dry_run_no_http(self):
+        client = _validated_client(dry_run=True)
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is True
+        assert "dry" in msg.lower()
+        mock_get.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_add_artist_lookup_missing_foreign_id_returns_failure(self):
+        client = _validated_client()
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.return_value = _mock_response(200, [
+                {"artistName": "Foo Fighters"}  # missing foreignArtistId
+            ])
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is False
+        mock_post.assert_not_called()

--- a/tests/test_lidarr.py
+++ b/tests/test_lidarr.py
@@ -1,0 +1,83 @@
+"""Tests for LidarrClient (mocked HTTP)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from octogen.api.lidarr import LidarrClient
+
+
+@pytest.fixture
+def client():
+    return LidarrClient(
+        url="http://lidarr.test",
+        api_key="abc123",
+        quality_profile="Standard",
+        metadata_profile="Standard",
+        tag="octogen",
+        monitored=False,
+        dry_run=False,
+    )
+
+
+def _mock_response(status_code=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.ok = 200 <= status_code < 300
+    return resp
+
+
+class TestValidate:
+
+    def test_validate_resolves_profiles_picks_root_creates_tag(self, client):
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.side_effect = [
+                _mock_response(200, [{"id": 1, "name": "Standard"}]),  # quality profile
+                _mock_response(200, [{"id": 2, "name": "Standard"}]),  # metadata profile
+                _mock_response(200, [{"id": 5, "path": "/music"}]),    # root folder
+                _mock_response(200, [{"id": 7, "label": "octogen"}]),  # tag (exists)
+            ]
+            client.validate()
+        assert client.quality_profile_id == 1
+        assert client.metadata_profile_id == 2
+        assert client.root_folder_path == "/music"
+        assert client.tag_id == 7
+        mock_post.assert_not_called()
+
+    def test_validate_creates_tag_if_missing(self, client):
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.side_effect = [
+                _mock_response(200, [{"id": 1, "name": "Standard"}]),
+                _mock_response(200, [{"id": 2, "name": "Standard"}]),
+                _mock_response(200, [{"id": 5, "path": "/music"}]),
+                _mock_response(200, []),  # tag list empty
+            ]
+            mock_post.return_value = _mock_response(201, {"id": 9, "label": "octogen"})
+            client.validate()
+        assert client.tag_id == 9
+        assert mock_post.call_count == 1
+
+    def test_validate_fails_when_quality_profile_unknown(self, client):
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
+            mock_get.return_value = _mock_response(200, [{"id": 1, "name": "Other"}])
+            with pytest.raises(RuntimeError, match="LIDARR_QUALITY_PROFILE"):
+                client.validate()
+
+    def test_validate_fails_when_unreachable(self, client):
+        from requests.exceptions import ConnectionError as ReqConnError
+        with patch("octogen.api.lidarr.requests.Session.get", side_effect=ReqConnError):
+            with pytest.raises(RuntimeError, match="unreachable"):
+                client.validate()
+
+    def test_validate_fails_when_no_root_folders(self, client):
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(200, [{"id": 1, "name": "Standard"}]),
+                _mock_response(200, [{"id": 2, "name": "Standard"}]),
+                _mock_response(200, []),  # no root folders
+            ]
+            with pytest.raises(RuntimeError, match="root folder"):
+                client.validate()

--- a/tests/test_lidarr.py
+++ b/tests/test_lidarr.py
@@ -82,6 +82,14 @@ class TestValidate:
             with pytest.raises(RuntimeError, match="root folder"):
                 client.validate()
 
+    def test_validate_wraps_unexpected_response_shape(self, client):
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
+            mock_get.return_value = _mock_response(
+                200, [{"name": "Standard"}]  # missing 'id'
+            )
+            with pytest.raises(RuntimeError, match="unexpected response shape"):
+                client.validate()
+
 
 def _validated_client(monitored=False, dry_run=False):
     c = LidarrClient(
@@ -178,3 +186,43 @@ class TestAddArtist:
             success, msg = client.add_artist("Foo Fighters")
         assert success is False
         mock_post.assert_not_called()
+
+    def test_add_artist_request_exception_returns_failure(self):
+        from requests.exceptions import ConnectionError as ReqConnError
+        client = _validated_client()
+        with patch(
+            "octogen.api.lidarr.requests.Session.get",
+            side_effect=ReqConnError("network down"),
+        ):
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is False
+        assert "network down" in msg
+
+    def test_add_artist_value_error_swallowed(self):
+        client = _validated_client()
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        bad_resp.ok = True
+        bad_resp.raise_for_status.return_value = None
+        bad_resp.json.side_effect = ValueError("not json")
+        with patch(
+            "octogen.api.lidarr.requests.Session.get", return_value=bad_resp,
+        ):
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is False
+        assert "not json" in msg
+
+    def test_add_artist_before_validate_returns_failure(self):
+        client = LidarrClient(
+            url="http://lidarr.test",
+            api_key="abc123",
+            quality_profile="Standard",
+            metadata_profile="Standard",
+            tag="octogen",
+            monitored=False,
+        )
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
+            success, msg = client.add_artist("Foo Fighters")
+        assert success is False
+        assert "validate" in msg.lower()
+        mock_get.assert_not_called()

--- a/tests/test_lidarr.py
+++ b/tests/test_lidarr.py
@@ -82,6 +82,56 @@ class TestValidate:
             with pytest.raises(RuntimeError, match="root folder"):
                 client.validate()
 
+    def test_validate_with_empty_tag_skips_tag_lookup(self):
+        """Setting LIDARR_TAG="" must skip the tag GET/POST entirely so the
+        operator can opt out of OctoGen's auto-tagging without breaking
+        validation."""
+        c = LidarrClient(
+            url="http://lidarr.test",
+            api_key="abc123",
+            quality_profile="Standard",
+            metadata_profile="Standard",
+            tag="",
+            monitored=False,
+        )
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.side_effect = [
+                _mock_response(200, [{"id": 1, "name": "Standard"}]),
+                _mock_response(200, [{"id": 2, "name": "Standard"}]),
+                _mock_response(200, [{"id": 5, "path": "/music"}]),
+            ]
+            c.validate()
+        assert c.tag_id is None
+        assert mock_get.call_count == 3  # quality, metadata, root only — no tag
+        mock_post.assert_not_called()
+
+    def test_add_artist_with_empty_tag_sends_empty_tags(self):
+        """When tag is empty, the POST payload must contain an empty tags
+        list (matches the existing dry-run-vs-real-run guard at lidarr.py:150)."""
+        c = LidarrClient(
+            url="http://lidarr.test",
+            api_key="abc123",
+            quality_profile="Standard",
+            metadata_profile="Standard",
+            tag="",
+            monitored=False,
+        )
+        c.quality_profile_id = 1
+        c.metadata_profile_id = 2
+        c.root_folder_path = "/music"
+        c.tag_id = None  # validate() leaves it None when tag=""
+
+        with patch("octogen.api.lidarr.requests.Session.get") as mock_get, \
+             patch("octogen.api.lidarr.requests.Session.post") as mock_post:
+            mock_get.return_value = _mock_response(200, [
+                {"foreignArtistId": "mb-001", "artistName": "Foo Fighters"}
+            ])
+            mock_post.return_value = _mock_response(201, {"id": 99})
+            c.add_artist("Foo Fighters")
+        sent = mock_post.call_args.kwargs["json"]
+        assert sent["tags"] == []
+
     def test_validate_wraps_unexpected_response_shape(self, client):
         with patch("octogen.api.lidarr.requests.Session.get") as mock_get:
             mock_get.return_value = _mock_response(

--- a/tests/test_lidarr_degrade.py
+++ b/tests/test_lidarr_degrade.py
@@ -1,0 +1,89 @@
+"""Regression guards for the Lidarr degrade-and-warn behavior.
+
+The bridge is documented as optional ("Failures during mid-run add operations
+are caught at the call site and never block playlist generation."). The
+v1 implementation contradicted this by calling sys.exit(1) on validate()
+failure, which took down the whole service when Lidarr was briefly
+unreachable, restarting, or had a typo'd profile name.
+
+Match the degrade-and-warn pattern used by Last.fm, ListenBrainz, and
+AudioMuse: log a warning, set self.lidarr = None, and continue.
+"""
+
+import re
+from pathlib import Path
+
+
+_MAIN = Path(__file__).resolve().parent.parent / "octogen" / "main.py"
+
+
+class TestLidarrValidateDegradeAndWarn:
+    @classmethod
+    def setup_class(cls):
+        cls.source = _MAIN.read_text(encoding="utf-8")
+
+    def test_validate_failure_does_not_call_sys_exit(self):
+        """Locks in the fix: the except RuntimeError branch must not
+        sys.exit. If a future commit reverts to sys.exit(1) in this block,
+        this test fails."""
+        # Match the Lidarr-specific except RuntimeError block and assert
+        # sys.exit does not appear inside it.
+        pattern = re.compile(
+            r"self\.lidarr\.validate\(\).*?"
+            r"except RuntimeError as e:\s*"
+            r"(.*?)"
+            r"(?=\n        \S|\nclass |\n    def )",
+            re.DOTALL,
+        )
+        match = pattern.search(self.source)
+        assert match, "Could not locate the Lidarr validate() except block"
+        block = match.group(1)
+        assert "sys.exit" not in block, (
+            "Lidarr validate() failure must not sys.exit — "
+            "it should log a warning and set self.lidarr = None to degrade gracefully"
+        )
+
+    def test_validate_failure_sets_lidarr_to_none(self):
+        """The degrade path must clear self.lidarr so downstream code
+        (_handle_missing_track) skips the Lidarr push branch."""
+        pattern = re.compile(
+            r"self\.lidarr\.validate\(\).*?"
+            r"except RuntimeError as e:.*?"
+            r"self\.lidarr\s*=\s*None",
+            re.DOTALL,
+        )
+        assert pattern.search(self.source), (
+            "Lidarr validate() failure must set self.lidarr = None"
+        )
+
+    def test_validate_failure_logs_warning_not_error(self):
+        """Failure-to-validate is a degraded state, not a hard error.
+        Use logger.warning so the noise level matches Last.fm/AudioMuse."""
+        pattern = re.compile(
+            r"self\.lidarr\.validate\(\).*?"
+            r"except RuntimeError as e:.*?"
+            r"logger\.warning\(",
+            re.DOTALL,
+        )
+        assert pattern.search(self.source), (
+            "Lidarr validate() failure should log at warning level"
+        )
+
+
+class TestLidarrPushErrorLogsTraceback:
+    @classmethod
+    def setup_class(cls):
+        cls.source = _MAIN.read_text(encoding="utf-8")
+
+    def test_push_error_uses_exc_info(self):
+        """The Lidarr push error path should log with exc_info=True so
+        the traceback is captured for diagnosis. Matches the DB error
+        path's exc_info=True (consistency)."""
+        pattern = re.compile(
+            r'logger\.warning\(\s*'
+            r'"Lidarr push error for %r: %s"[^)]*?exc_info\s*=\s*True',
+            re.DOTALL,
+        )
+        assert pattern.search(self.source), (
+            "Lidarr push-error log must include exc_info=True for traceback capture"
+        )

--- a/tests/test_missing_artists.py
+++ b/tests/test_missing_artists.py
@@ -1,0 +1,79 @@
+"""Tests for missing_artists tracking on RatingsCache."""
+
+import sqlite3
+
+import pytest
+
+from octogen.storage.cache import RatingsCache
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return RatingsCache(tmp_path / "test.db")
+
+
+class TestRecordMissingTrack:
+
+    def test_first_record_returns_count_1(self, cache):
+        assert cache.record_missing_track("Foo Fighters") == 1
+
+    def test_second_record_increments(self, cache):
+        cache.record_missing_track("Foo Fighters")
+        assert cache.record_missing_track("Foo Fighters") == 2
+
+    def test_normalization_case_insensitive(self, cache):
+        cache.record_missing_track("Foo Fighters")
+        assert cache.record_missing_track("foo fighters") == 2
+
+    def test_normalization_strips_whitespace(self, cache):
+        cache.record_missing_track("Foo Fighters")
+        assert cache.record_missing_track("  Foo Fighters  ") == 2
+
+    def test_display_name_preserves_first_seen_casing(self, cache, tmp_path):
+        cache.record_missing_track("Foo Fighters")
+        cache.record_missing_track("foo fighters")
+        with sqlite3.connect(tmp_path / "test.db") as conn:
+            row = conn.execute(
+                "SELECT artist_display FROM missing_artists WHERE artist=?",
+                ("foo fighters",),
+            ).fetchone()
+        assert row[0] == "Foo Fighters"
+
+
+class TestMarkPushed:
+
+    def test_mark_pushed_sets_timestamp(self, cache, tmp_path):
+        cache.record_missing_track("Foo Fighters")
+        cache.mark_pushed("Foo Fighters")
+        with sqlite3.connect(tmp_path / "test.db") as conn:
+            row = conn.execute(
+                "SELECT pushed_to_lidarr FROM missing_artists WHERE artist=?",
+                ("foo fighters",),
+            ).fetchone()
+        assert row[0] is not None
+
+    def test_mark_pushed_idempotent(self, cache):
+        cache.record_missing_track("Foo Fighters")
+        cache.mark_pushed("Foo Fighters")
+        cache.mark_pushed("Foo Fighters")  # must not raise
+
+
+class TestGetPendingPushes:
+
+    def test_returns_only_artists_at_or_above_threshold(self, cache):
+        cache.record_missing_track("Below")
+        cache.record_missing_track("AtThreshold")
+        cache.record_missing_track("AtThreshold")
+        cache.record_missing_track("AtThreshold")
+        cache.record_missing_track("Above")
+        cache.record_missing_track("Above")
+        cache.record_missing_track("Above")
+        cache.record_missing_track("Above")
+        result = cache.get_pending_pushes(threshold=3)
+        assert sorted(result) == sorted(["AtThreshold", "Above"])
+
+    def test_excludes_already_pushed(self, cache):
+        for _ in range(3):
+            cache.record_missing_track("Foo Fighters")
+        cache.mark_pushed("Foo Fighters")
+        assert cache.get_pending_pushes(threshold=3) == []

--- a/tests/test_missing_artists.py
+++ b/tests/test_missing_artists.py
@@ -77,3 +77,24 @@ class TestGetPendingPushes:
             cache.record_missing_track("Foo Fighters")
         cache.mark_pushed("Foo Fighters")
         assert cache.get_pending_pushes(threshold=3) == []
+
+
+class TestPushAttemptCap:
+
+    def test_increment_push_attempt_returns_count(self, cache):
+        cache.record_missing_track("Foo Fighters")
+        assert cache.increment_push_attempt("Foo Fighters") == 1
+        assert cache.increment_push_attempt("Foo Fighters") == 2
+
+    def test_pending_excludes_after_max_attempts(self, cache):
+        for _ in range(3):
+            cache.record_missing_track("Foo Fighters")
+        for _ in range(5):
+            cache.increment_push_attempt("Foo Fighters")
+        assert cache.get_pending_pushes(threshold=3, max_attempts=5) == []
+
+    def test_pending_includes_below_max_attempts(self, cache):
+        for _ in range(3):
+            cache.record_missing_track("Foo Fighters")
+        cache.increment_push_attempt("Foo Fighters")
+        assert cache.get_pending_pushes(threshold=3, max_attempts=5) == ["Foo Fighters"]

--- a/tests/test_missing_artists.py
+++ b/tests/test_missing_artists.py
@@ -98,3 +98,28 @@ class TestPushAttemptCap:
             cache.record_missing_track("Foo Fighters")
         cache.increment_push_attempt("Foo Fighters")
         assert cache.get_pending_pushes(threshold=3, max_attempts=5) == ["Foo Fighters"]
+
+
+class TestMigration:
+    """Pre-existing DBs created before push_attempt_count must be upgraded
+    in place rather than crashing the engine at startup."""
+
+    def test_legacy_db_without_push_attempt_count_is_migrated(self, tmp_path):
+        db_path = tmp_path / "legacy.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """CREATE TABLE missing_artists (
+                    artist TEXT PRIMARY KEY,
+                    artist_display TEXT NOT NULL,
+                    missing_count INTEGER NOT NULL DEFAULT 0,
+                    first_seen TEXT NOT NULL,
+                    last_seen TEXT NOT NULL,
+                    pushed_to_lidarr TEXT
+                )"""
+            )
+            conn.commit()
+
+        cache = RatingsCache(db_path)  # must not raise
+
+        assert cache.record_missing_track("Foo Fighters") == 1
+        assert cache.increment_push_attempt("Foo Fighters") == 1


### PR DESCRIPTION
When OctoGen encounters a track whose artist isn't in the local library, the only existing path is to ask Octo-Fiesta to download the specific album. For users who run Lidarr for music management, it's more useful to push the artist to Lidarr after they've shown up `LIDARR_MIN_MISSING` times — Lidarr will then monitor and download the artist's full discography per its quality profile rules.

This bridge is purely additive: it runs alongside Octo-Fiesta when both are configured, only fires after the threshold is met, and silently no-ops when `LIDARR_URL` is unset.

**Depends on #49** (OCTOFIESTA_ENABLED toggle). This PR is opened against `main` for visibility, but the diff below the dashed line is the toggle PR; please merge #49 first and I'll rebase to drop those commits.

## Changes

### Config + models

- **`octogen/models/config_models.py`** — new `LidarrConfig` with `url`, `api_key`, `min_missing` (default 3, ≥1), `add_monitored`, `tag`, `quality_profile`, `metadata_profile`. URL validator mirrors the existing Navidrome pattern.
- **`octogen/config.py`** / **`octogen/main.py`** — parse `LIDARR_*` env vars; bridge is implicitly enabled when `LIDARR_URL` is set.

### Lidarr API client

- **`octogen/api/lidarr.py`** *(new)* — `LidarrClient`:
  - `validate()` resolves quality/metadata profile names → IDs and picks a root folder; raises `RuntimeError` on bad config so the engine fails fast at startup.
  - `add_artist(name)` does a MusicBrainz lookup via Lidarr's `/api/v1/artist/lookup`, then POSTs the artist. Never raises — returns `(success, message)`. Treats HTTP 409 as success (already-added). Honors `dry_run` from engine.
  - Uses `requests.Session` with the `X-Api-Key` header set once.

### Storage

- **`octogen/storage/cache.py`** — new `missing_artists` table:

```sql
artist TEXT PRIMARY KEY,
artist_display TEXT NOT NULL,
missing_count INTEGER NOT NULL DEFAULT 0,
first_seen TEXT NOT NULL,
last_seen TEXT NOT NULL,
pushed_to_lidarr TEXT,
push_attempt_count INTEGER NOT NULL DEFAULT 0
```

  Methods: `record_missing_track`, `mark_pushed`, `increment_push_attempt`, `get_pending_pushes`, `is_pending_push`. Artist names are normalized (`strip().lower()`) for the PK so casing/whitespace variants collapse to one row. `push_attempt_count` caps retries at 5 to prevent storms on persistently-failing artists. Idempotent `ALTER TABLE` migration for existing DBs.

### Engine wiring

- **`octogen/main.py:_handle_missing_track`** — when `self.lidarr` exists, records the missing track, and once the per-artist count hits `LIDARR_MIN_MISSING`, calls `add_artist`. Lidarr push is best-effort: DB and HTTP errors are logged but never block the Octo-Fiesta path. New stats: `lidarr_added`, `lidarr_below_threshold`.

### Health probe

- **`octogen/web/health.py`** — `check_lidarr()` probes `/api/v1/system/status` with the API key from `load_secret` (Docker-secret-aware). Adds Lidarr to `get_all_services()` for the dashboard.

### Tests (47 new, total 80)

- `tests/test_lidarr.py` — `LidarrClient.validate()` and `add_artist()`, including unexpected-response-shape, request-exception, and validate-before-call paths.
- `tests/test_missing_artists.py` — `missing_artists` table: normalization, threshold filtering, push-attempt cap.
- `tests/test_handle_missing_track.py` — `_handle_missing_track` integration: threshold gating, retry cap, DB error logging, push-exception logging, combined OctoFiesta-disabled path.
- `tests/test_health_lidarr.py` — `check_lidarr` health probe states.
- `tests/test_config.py` — `LidarrConfig` env loading.

### Docs

- **`README.md`** / **`docs/ENV_VARS.md`** — document `LIDARR_URL`, `LIDARR_API_KEY`, `LIDARR_MIN_MISSING`, `LIDARR_ADD_MONITORED`, `LIDARR_TAG`, `LIDARR_QUALITY_PROFILE`, `LIDARR_METADATA_PROFILE`.
