### PR TITLE
Add TIMEOFDAY_PLAYLISTS_PERSIST toggle to keep all four time-of-day playlists

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -568,7 +568,7 @@ TIMEOFDAY_ENABLED=true
 - **Night Vibes**: Generates at 10:00 PM only
 - Duplicate prevention: Won't regenerate within 1 hour
 - Respects TZ environment variable for timezone
-- Auto-deletes previous period's playlist when generating new one
+- Auto-deletes previous period's playlist when generating new one (override with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
 
 ---
 
@@ -614,6 +614,21 @@ TIMEOFDAY_MORNING_START=4
 - **Afternoon (10-16)**: Balanced, productive, moderate energy
 - **Evening (16-22)**: Chill, relaxing, wind-down music
 - **Night (22-4)**: Ambient, calm, sleep-friendly
+
+---
+
+### TIMEOFDAY_PLAYLISTS_PERSIST
+**Description**: Keep all four time-of-day playlists in Navidrome instead of deleting the inactive ones  
+**Default**: `false`  
+**Options**: `true`, `false`  
+**Example**:
+```bash
+TIMEOFDAY_PLAYLISTS_PERSIST=true
+```
+**Notes**:
+- Default (`false`): only the current period's playlist exists at any time; the other three are deleted when a new period generates
+- When `true`: Morning Mix, Afternoon Flow, Evening Chill, and Night Vibes all persist; the current period's playlist is still updated in place on each scheduled run
+- Useful if you want a stable set of mood playlists pinned in your client rather than a single rotating one
 
 ---
 

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -620,7 +620,7 @@ TIMEOFDAY_MORNING_START=4
 ### TIMEOFDAY_PLAYLISTS_PERSIST
 **Description**: Keep all four time-of-day playlists in Navidrome instead of deleting the inactive ones  
 **Default**: `false`  
-**Options**: `true`, `false`  
+**Options**: `true`, `1`, `yes`, `on` (case-insensitive) enable; anything else is treated as `false`  
 **Example**:
 ```bash
 TIMEOFDAY_PLAYLISTS_PERSIST=true

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -568,7 +568,7 @@ TIMEOFDAY_ENABLED=true
 - **Night Vibes**: Generates at 10:00 PM only
 - Duplicate prevention: Won't regenerate within 1 hour
 - Respects TZ environment variable for timezone
-- Auto-deletes previous period's playlist when generating new one (override with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
+- Auto-deletes inactive periods' playlists when generating new one (override with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
 
 ---
 

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -627,7 +627,8 @@ TIMEOFDAY_PLAYLISTS_PERSIST=true
 ```
 **Notes**:
 - Default (`false`): only the current period's playlist exists at any time; the other three are deleted when a new period generates
-- When `true`: Morning Mix, Afternoon Flow, Evening Chill, and Night Vibes all persist; the current period's playlist is still updated in place on each scheduled run
+- When `true`: Morning Mix, Afternoon Flow, Evening Chill, and Night Vibes all persist; the current period's playlist is still deleted-and-recreated on each scheduled run (its playlist id changes)
+- Pre-existing period playlists are not retroactively repopulated when this flag is first enabled
 - Useful if you want a stable set of mood playlists pinned in your client rather than a single rotating one
 
 ---
@@ -1385,7 +1386,7 @@ docker logs octogen | grep "Timezone:"
 | **Scheduling** | 2 | SCHEDULE_CRON, TZ, MIN_RUN_INTERVAL_HOURS |
 | **Monitoring** | 4 | METRICS_ENABLED, METRICS_PORT, CIRCUIT_BREAKER_THRESHOLD, CIRCUIT_BREAKER_TIMEOUT |
 | **Web UI** | 2 | WEB_ENABLED, WEB_PORT |
-| **Time-of-Day** | 11 | TIMEOFDAY_ENABLED, TIMEOFDAY_*_START, TIMEOFDAY_*_END, TIMEOFDAY_PLAYLIST_SIZE, TIMEOFDAY_REFRESH_ON_PERIOD_CHANGE |
+| **Time-of-Day** | 12 | TIMEOFDAY_ENABLED, TIMEOFDAY_*_START, TIMEOFDAY_*_END, TIMEOFDAY_PLAYLIST_SIZE, TIMEOFDAY_PLAYLISTS_PERSIST, TIMEOFDAY_REFRESH_ON_PERIOD_CHANGE |
 | **Batch Processing** | 2 | DOWNLOAD_BATCH_SIZE, DOWNLOAD_CONCURRENCY |
 | **Logging** | 2 | LOG_FORMAT, SHOW_PROGRESS |
 | **Templates** | 1 | PLAYLIST_TEMPLATES_FILE |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Automatic mood-appropriate playlists that rotate based on time of day:
 **Features**:
 - ✅ Hybrid generation: 25 songs from AudioMuse-AI + 5 from LLM
 - ✅ Auto-rotates when time period changes
-- ✅ Auto-deletes previous period's playlist
+- ✅ Auto-deletes previous period's playlist (or keep all four pinned with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
 - ✅ Configurable time boundaries
 - ✅ LLM prompts enhanced with time-of-day context
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Automatic mood-appropriate playlists that rotate based on time of day:
 **Features**:
 - ✅ Hybrid generation: 25 songs from AudioMuse-AI + 5 from LLM
 - ✅ Auto-rotates when time period changes
-- ✅ Auto-deletes previous period's playlist (or keep all four pinned with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
+- ✅ Auto-deletes inactive periods' playlists when generating a new one (or keep all four pinned with `TIMEOFDAY_PLAYLISTS_PERSIST=true`)
 - ✅ Configurable time boundaries
 - ✅ LLM prompts enhanced with time-of-day context
 

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -10,7 +10,7 @@ from octogen.utils.secrets import load_secret
 from octogen.models.config_models import (
     OctoGenConfig, NavidromeConfig, OctoFiestaConfig, AIConfig,
     LastFMConfig, ListenBrainzConfig, AudioMuseConfig,
-    SpotifyConfig, DeezerConfig,
+    SpotifyConfig, DeezerConfig, PlaylistsConfig,
     PerformanceConfig, SchedulingConfig, MonitoringConfig,
     WebUIConfig, LoggingConfig
 )
@@ -99,6 +99,11 @@ def load_config_from_env() -> Dict:
             "enabled": os.getenv("DEEZER_IMPORT_ENABLED", "false").lower() == "true",
             "playlist_urls": os.getenv("DEEZER_PLAYLIST_URLS", ""),
         },
+        "playlists": {
+            "time_of_day_persist": os.getenv(
+                "TIMEOFDAY_PLAYLISTS_PERSIST", "false"
+            ).lower() == "true",
+        },
         "performance": {
             "album_batch_size": int(os.getenv("ALBUM_BATCH_SIZE", "500")),
             "max_albums_scan": int(os.getenv("MAX_ALBUMS_SCAN", "10000")),
@@ -152,6 +157,7 @@ def validate_config(config: Dict) -> Optional[OctoGenConfig]:
             audiomuse=AudioMuseConfig(**config["audiomuse"]) if config["audiomuse"]["enabled"] else None,
             spotify=SpotifyConfig(**config["spotify"]) if config.get("spotify", {}).get("enabled") else None,
             deezer=DeezerConfig(**config["deezer"]) if config.get("deezer", {}).get("enabled") else None,
+            playlists=PlaylistsConfig(**config.get("playlists", {})),
             performance=PerformanceConfig(**config["performance"]),
             scheduling=SchedulingConfig(**config["scheduling"]),
             monitoring=MonitoringConfig(**config["monitoring"]),

--- a/octogen/config.py
+++ b/octogen/config.py
@@ -102,7 +102,7 @@ def load_config_from_env() -> Dict:
         "playlists": {
             "time_of_day_persist": os.getenv(
                 "TIMEOFDAY_PLAYLISTS_PERSIST", "false"
-            ).lower() == "true",
+            ).lower() in ("true", "1", "yes", "on"),
         },
         "performance": {
             "album_batch_size": int(os.getenv("ALBUM_BATCH_SIZE", "500")),

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -298,9 +298,9 @@ class OctoGenEngine:
                 "playlist_urls": os.getenv("DEEZER_PLAYLIST_URLS", ""),
             },
             "playlists": {
-                "time_of_day_persist": os.getenv(
-                    "TIMEOFDAY_PLAYLISTS_PERSIST", "false"
-                ).lower() == "true",
+                "time_of_day_persist": self._get_env_bool(
+                    "TIMEOFDAY_PLAYLISTS_PERSIST", False
+                ),
             },
         }
 
@@ -333,16 +333,15 @@ class OctoGenEngine:
         except ValueError:
             return default
 
-    _PERIOD_PLAYLIST_PATTERNS = (
+    _PERIOD_PLAYLIST_PATTERNS = frozenset({
         "Morning Mix", "Afternoon Flow", "Evening Chill", "Night Vibes",
-    )
+    })
 
     def _cleanup_other_period_playlists(self, current_playlist_name: str) -> None:
-        """Delete the three time-of-day playlists for inactive periods.
-
-        Skipped when ``playlists.time_of_day_persist`` is True so all four
-        playlists coexist; the current period's playlist is still refreshed
-        in place by ``nd.create_playlist`` later in the flow.
+        """Skipped when ``playlists.time_of_day_persist`` is True so all four
+        period playlists coexist; the current period's playlist is still
+        deleted-and-recreated by ``nd.create_playlist`` later in the flow
+        (its playlist id changes on every run).
         """
         if self.config["playlists"]["time_of_day_persist"]:
             logger.info(
@@ -352,18 +351,32 @@ class OctoGenEngine:
 
         try:
             all_playlists_in_navidrome = self.nd.get_all_playlists()
-            for nd_playlist in all_playlists_in_navidrome:
-                nd_playlist_name = nd_playlist.get("name", "")
-                is_period = nd_playlist_name in self._PERIOD_PLAYLIST_PATTERNS
-                if is_period and nd_playlist_name != current_playlist_name:
-                    playlist_id = nd_playlist.get("id")
-                    if playlist_id:
-                        logger.info(
-                            "🗑️  Deleting old period playlist: %s", nd_playlist_name
-                        )
-                        self.nd.delete_playlist(playlist_id)
         except Exception as e:
-            logger.warning("Could not delete old period playlists: %s", e)
+            logger.warning("Could not list playlists for period cleanup: %s", e)
+            return
+
+        for nd_playlist in all_playlists_in_navidrome:
+            nd_playlist_name = nd_playlist.get("name", "")
+            if (
+                nd_playlist_name not in self._PERIOD_PLAYLIST_PATTERNS
+                or nd_playlist_name == current_playlist_name
+            ):
+                continue
+            playlist_id = nd_playlist.get("id")
+            if not playlist_id:
+                continue
+            logger.info("🗑️  Deleting old period playlist: %s", nd_playlist_name)
+            try:
+                if not self.nd.delete_playlist(playlist_id):
+                    logger.warning(
+                        "delete_playlist returned False for %s (id: %s)",
+                        nd_playlist_name, playlist_id,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to delete period playlist %s (id: %s): %s",
+                    nd_playlist_name, playlist_id, e,
+                )
 
     def _validate_env_config(self) -> None:
         """Validate environment configuration"""

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -298,9 +298,9 @@ class OctoGenEngine:
                 "playlist_urls": os.getenv("DEEZER_PLAYLIST_URLS", ""),
             },
             "playlists": {
-                "time_of_day_persist": self._get_env_bool(
-                    "TIMEOFDAY_PLAYLISTS_PERSIST", False
-                ),
+                "time_of_day_persist": os.getenv(
+                    "TIMEOFDAY_PLAYLISTS_PERSIST", "false"
+                ).lower() == "true",
             },
         }
 
@@ -354,10 +354,7 @@ class OctoGenEngine:
             all_playlists_in_navidrome = self.nd.get_all_playlists()
             for nd_playlist in all_playlists_in_navidrome:
                 nd_playlist_name = nd_playlist.get("name", "")
-                is_period = any(
-                    pattern in nd_playlist_name
-                    for pattern in self._PERIOD_PLAYLIST_PATTERNS
-                )
+                is_period = nd_playlist_name in self._PERIOD_PLAYLIST_PATTERNS
                 if is_period and nd_playlist_name != current_playlist_name:
                     playlist_id = nd_playlist.get("id")
                     if playlist_id:

--- a/octogen/main.py
+++ b/octogen/main.py
@@ -297,6 +297,11 @@ class OctoGenEngine:
                 "enabled": self._get_env_bool("DEEZER_IMPORT_ENABLED", False),
                 "playlist_urls": os.getenv("DEEZER_PLAYLIST_URLS", ""),
             },
+            "playlists": {
+                "time_of_day_persist": self._get_env_bool(
+                    "TIMEOFDAY_PLAYLISTS_PERSIST", False
+                ),
+            },
         }
 
         # Log configuration (without secrets)
@@ -327,6 +332,41 @@ class OctoGenEngine:
             return int(os.getenv(key, str(default)))
         except ValueError:
             return default
+
+    _PERIOD_PLAYLIST_PATTERNS = (
+        "Morning Mix", "Afternoon Flow", "Evening Chill", "Night Vibes",
+    )
+
+    def _cleanup_other_period_playlists(self, current_playlist_name: str) -> None:
+        """Delete the three time-of-day playlists for inactive periods.
+
+        Skipped when ``playlists.time_of_day_persist`` is True so all four
+        playlists coexist; the current period's playlist is still refreshed
+        in place by ``nd.create_playlist`` later in the flow.
+        """
+        if self.config["playlists"]["time_of_day_persist"]:
+            logger.info(
+                "🔒 Time-of-day playlist persistence enabled, keeping other periods"
+            )
+            return
+
+        try:
+            all_playlists_in_navidrome = self.nd.get_all_playlists()
+            for nd_playlist in all_playlists_in_navidrome:
+                nd_playlist_name = nd_playlist.get("name", "")
+                is_period = any(
+                    pattern in nd_playlist_name
+                    for pattern in self._PERIOD_PLAYLIST_PATTERNS
+                )
+                if is_period and nd_playlist_name != current_playlist_name:
+                    playlist_id = nd_playlist.get("id")
+                    if playlist_id:
+                        logger.info(
+                            "🗑️  Deleting old period playlist: %s", nd_playlist_name
+                        )
+                        self.nd.delete_playlist(playlist_id)
+        except Exception as e:
+            logger.warning("Could not delete old period playlists: %s", e)
 
     def _validate_env_config(self) -> None:
         """Validate environment configuration"""
@@ -1537,21 +1577,7 @@ CRITICAL RULES:
                     logger.info(f"Playlist: {playlist_name}")
                     logger.info(f"Reason: {reason}")
                     
-                    # Delete old period playlists first
-                    try:
-                        all_playlists_in_navidrome = self.nd.get_all_playlists()
-                        period_patterns = ["Morning Mix", "Afternoon Flow", "Evening Chill", "Night Vibes"]
-                        
-                        for nd_playlist in all_playlists_in_navidrome:
-                            nd_playlist_name = nd_playlist.get("name", "")
-                            # Delete if it's a time-period playlist but not the current one
-                            if any(pattern in nd_playlist_name for pattern in period_patterns) and nd_playlist_name != playlist_name:
-                                playlist_id = nd_playlist.get("id")
-                                if playlist_id:
-                                    logger.info(f"🗑️  Deleting old period playlist: {nd_playlist_name}")
-                                    self.nd.delete_playlist(playlist_id)
-                    except Exception as e:
-                        logger.warning(f"Could not delete old period playlists: {e}")
+                    self._cleanup_other_period_playlists(playlist_name)
                     
                     # Generate the time-period playlist
                     # Use AudioMuse for 25 songs, LLM for 5 songs

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -120,8 +120,8 @@ class PlaylistsConfig(BaseModel):
             "When False, generating a new time-of-day playlist deletes the "
             "other three (Morning Mix / Afternoon Flow / Evening Chill / "
             "Night Vibes) so only the current period's playlist exists. "
-            "When True, all four persist and the current period's playlist "
-            "is updated in place on each run."
+            "When True, all four persist; the current period's playlist is "
+            "still deleted-and-recreated on each run (its id changes)."
         ),
     )
 

--- a/octogen/models/config_models.py
+++ b/octogen/models/config_models.py
@@ -112,6 +112,20 @@ class DeezerConfig(BaseModel):
     playlist_urls: str = Field("", description="Comma-separated playlist URLs")
 
 
+class PlaylistsConfig(BaseModel):
+    """Playlist behavior configuration"""
+    time_of_day_persist: bool = Field(
+        False,
+        description=(
+            "When False, generating a new time-of-day playlist deletes the "
+            "other three (Morning Mix / Afternoon Flow / Evening Chill / "
+            "Night Vibes) so only the current period's playlist exists. "
+            "When True, all four persist and the current period's playlist "
+            "is updated in place on each run."
+        ),
+    )
+
+
 class PerformanceConfig(BaseModel):
     """Performance configuration"""
     album_batch_size: int = Field(500, ge=1, le=5000)
@@ -185,6 +199,7 @@ class OctoGenConfig(BaseModel):
     audiomuse: Optional[AudioMuseConfig] = None
     spotify: Optional[SpotifyConfig] = None
     deezer: Optional[DeezerConfig] = None
+    playlists: PlaylistsConfig = Field(default_factory=PlaylistsConfig)
     performance: PerformanceConfig = Field(default_factory=PerformanceConfig)
     scheduling: SchedulingConfig = Field(default_factory=SchedulingConfig)
     monitoring: MonitoringConfig = Field(default_factory=MonitoringConfig)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,11 +186,23 @@ class TestTimeOfDayPlaylistsPersist:
             config = load_config_from_env()
         assert config["playlists"]["time_of_day_persist"] is False
 
-    def test_arbitrary_value_treated_as_false(self):
-        """Anything not equal to `true` (case-insensitive) is False."""
+    def test_truthy_aliases_enable(self):
+        """Other truthy aliases (1, yes, on) also enable, matching project convention."""
+        for value in ("1", "yes", "on", "YES", "On"):
+            with patch.dict(
+                os.environ,
+                {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": value},
+            ):
+                config = load_config_from_env()
+            assert config["playlists"]["time_of_day_persist"] is True, (
+                f"expected {value!r} to enable persistence"
+            )
+
+    def test_unknown_value_treated_as_false(self):
+        """A value outside the truthy set (e.g. 'maybe') is False."""
         with patch.dict(
             os.environ,
-            {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": "yes"},
+            {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": "maybe"},
         ):
             config = load_config_from_env()
         assert config["playlists"]["time_of_day_persist"] is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,3 +155,90 @@ class TestHybridDailyMixWithoutOctoFiesta:
         )
         assert len(songs) == 30
         engine._generate_llm_songs_for_daily_mix.assert_called_once()
+
+
+class TestTimeOfDayPlaylistsPersist:
+    """Tests for the TIMEOFDAY_PLAYLISTS_PERSIST toggle."""
+
+    def test_default_is_false(self):
+        """When unset, the toggle defaults to False (preserve existing behavior)."""
+        env = {**_REQUIRED_ENV}
+        env.pop("TIMEOFDAY_PLAYLISTS_PERSIST", None)
+        with patch.dict(os.environ, env, clear=True):
+            config = load_config_from_env()
+        assert config["playlists"]["time_of_day_persist"] is False
+
+    def test_true(self):
+        """`true` enables persistence."""
+        with patch.dict(
+            os.environ,
+            {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": "true"},
+        ):
+            config = load_config_from_env()
+        assert config["playlists"]["time_of_day_persist"] is True
+
+    def test_false_explicit(self):
+        """Explicit `false` keeps it disabled."""
+        with patch.dict(
+            os.environ,
+            {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": "false"},
+        ):
+            config = load_config_from_env()
+        assert config["playlists"]["time_of_day_persist"] is False
+
+    def test_arbitrary_value_treated_as_false(self):
+        """Anything not equal to `true` (case-insensitive) is False."""
+        with patch.dict(
+            os.environ,
+            {**_REQUIRED_ENV, "TIMEOFDAY_PLAYLISTS_PERSIST": "yes"},
+        ):
+            config = load_config_from_env()
+        assert config["playlists"]["time_of_day_persist"] is False
+
+
+class TestCleanupOtherPeriodPlaylists:
+    """Tests for the _cleanup_other_period_playlists gating helper."""
+
+    @staticmethod
+    def _make_engine(persist: bool, existing: list[dict]) -> OctoGenEngine:
+        """Build an engine instance with just enough state for the helper."""
+        engine = OctoGenEngine.__new__(OctoGenEngine)
+        engine.config = {"playlists": {"time_of_day_persist": persist}}
+        engine.nd = MagicMock()
+        engine.nd.get_all_playlists.return_value = existing
+        return engine
+
+    def test_persist_true_skips_delete(self):
+        """When the toggle is on, no delete calls fire even if old periods exist."""
+        engine = self._make_engine(
+            persist=True,
+            existing=[
+                {"id": "1", "name": "Morning Mix"},
+                {"id": "2", "name": "Afternoon Flow"},
+            ],
+        )
+        engine._cleanup_other_period_playlists("Evening Chill")
+        engine.nd.get_all_playlists.assert_not_called()
+        engine.nd.delete_playlist.assert_not_called()
+
+    def test_persist_false_deletes_only_other_periods(self):
+        """Default behavior: delete other period playlists, never the current one."""
+        engine = self._make_engine(
+            persist=False,
+            existing=[
+                {"id": "1", "name": "Morning Mix"},
+                {"id": "2", "name": "Afternoon Flow"},
+                {"id": "3", "name": "Evening Chill"},  # current
+                {"id": "4", "name": "My Hand-Curated Mix"},
+            ],
+        )
+        engine._cleanup_other_period_playlists("Evening Chill")
+        deleted_ids = [c.args[0] for c in engine.nd.delete_playlist.call_args_list]
+        assert sorted(deleted_ids) == ["1", "2"]
+
+    def test_persist_false_swallows_errors(self):
+        """A failure listing playlists is logged but never raised."""
+        engine = self._make_engine(persist=False, existing=[])
+        engine.nd.get_all_playlists.side_effect = RuntimeError("boom")
+        engine._cleanup_other_period_playlists("Morning Mix")
+        engine.nd.delete_playlist.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,3 +242,33 @@ class TestCleanupOtherPeriodPlaylists:
         engine.nd.get_all_playlists.side_effect = RuntimeError("boom")
         engine._cleanup_other_period_playlists("Morning Mix")
         engine.nd.delete_playlist.assert_not_called()
+
+    def test_per_iteration_delete_failure_does_not_abort_loop(self):
+        """A single delete raising should not skip the remaining periods."""
+        engine = self._make_engine(
+            persist=False,
+            existing=[
+                {"id": "1", "name": "Morning Mix"},
+                {"id": "2", "name": "Afternoon Flow"},
+                {"id": "3", "name": "Night Vibes"},
+            ],
+        )
+        engine.nd.delete_playlist.side_effect = [RuntimeError("nope"), True, True]
+        engine._cleanup_other_period_playlists("Evening Chill")
+        # All three deletes attempted despite the first one raising.
+        assert engine.nd.delete_playlist.call_count == 3
+
+
+class TestPeriodPatternsMatchScheduler:
+    """Drift-guard: _PERIOD_PLAYLIST_PATTERNS must equal the names produced
+    by octogen.scheduler.timeofday.get_period_display_name(). If a period is
+    renamed in one place but not the other, cleanup silently no-ops on the
+    renamed playlist forever."""
+
+    def test_patterns_match_scheduler_names(self):
+        from octogen.scheduler.timeofday import get_period_display_name
+        scheduler_names = {
+            get_period_display_name(p)
+            for p in ("morning", "afternoon", "evening", "night")
+        }
+        assert set(OctoGenEngine._PERIOD_PLAYLIST_PATTERNS) == scheduler_names


### PR DESCRIPTION
By default, OctoGen deletes the three inactive time-of-day playlists every time a new period generates, so only the current one (Morning Mix / Afternoon Flow / Evening Chill / Night Vibes) ever exists in Navidrome.

This PR adds an optional `TIMEOFDAY_PLAYLISTS_PERSIST` env var (default `false`, preserving existing behavior). When set to `true`, all four playlists persist in your library and only the current period's playlist is refreshed on each scheduled run via the existing delete-and-recreate inside `nd.create_playlist`.

This is useful if you want a stable set of mood playlists pinned in your client (e.g. a sidebar or starred set) rather than a single rotating one. The naming follows the existing `TIMEOFDAY_*` convention (`TIMEOFDAY_ENABLED`, `TIMEOFDAY_PLAYLIST_SIZE`, etc.).

## Changes

- **`octogen/models/config_models.py`**: new `PlaylistsConfig` pydantic model (`time_of_day_persist: bool = False`); wired into `OctoGenConfig` with `default_factory` so `config["playlists"]` is always present.
- **`octogen/config.py`** / **`octogen/main.py:_load_config_from_env`**: parse `TIMEOFDAY_PLAYLISTS_PERSIST` in both config loaders.
- **`octogen/main.py`**: extract the delete-other-periods loop into `_cleanup_other_period_playlists()` so the gating logic is testable in isolation. The patterns list is hoisted to a class-level constant.
- **`tests/test_config.py`**: 4 env-parsing tests (default, true, false, non-true value) plus 3 gating tests (persist=true skips delete; persist=false deletes only the other periods, never the current one; errors in `get_all_playlists` are swallowed). 37/37 total tests passing.
- **`ENV_VARS.md`** / **`README.md`**: document the new variable.
